### PR TITLE
feat: activity start/end signals for manual VAD control

### DIFF
--- a/agent/live_request_queue.go
+++ b/agent/live_request_queue.go
@@ -97,6 +97,16 @@ func (q *LiveRequestQueue) Done() <-chan struct{} {
 	return q.done
 }
 
+// SendActivityStart enqueues an activity-start signal for manual VAD control.
+func (q *LiveRequestQueue) SendActivityStart(ctx context.Context) error {
+	return q.Send(ctx, &model.LiveRequest{ActivityStart: true})
+}
+
+// SendActivityEnd enqueues an activity-end signal for manual VAD control.
+func (q *LiveRequestQueue) SendActivityEnd(ctx context.Context) error {
+	return q.Send(ctx, &model.LiveRequest{ActivityEnd: true})
+}
+
 // ModelSpeaking returns whether the model is currently producing audio output.
 func (q *LiveRequestQueue) ModelSpeaking() bool {
 	return atomic.LoadInt32(&q.modelSpeaking) == 1

--- a/agent/live_request_queue_test.go
+++ b/agent/live_request_queue_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSendActivityStart(t *testing.T) {
+	t.Parallel()
+
+	q := NewLiveRequestQueue(10)
+	defer q.Close()
+
+	if err := q.SendActivityStart(context.Background()); err != nil {
+		t.Fatalf("SendActivityStart() error = %v", err)
+	}
+
+	select {
+	case req := <-q.Events():
+		if !req.ActivityStart {
+			t.Error("expected ActivityStart = true")
+		}
+		if req.ActivityEnd {
+			t.Error("expected ActivityEnd = false")
+		}
+		if req.Content != nil || req.RealtimeInput != nil || req.ToolResponse != nil {
+			t.Error("expected only ActivityStart to be set")
+		}
+	default:
+		t.Fatal("expected a message in the queue")
+	}
+}
+
+func TestSendActivityEnd(t *testing.T) {
+	t.Parallel()
+
+	q := NewLiveRequestQueue(10)
+	defer q.Close()
+
+	if err := q.SendActivityEnd(context.Background()); err != nil {
+		t.Fatalf("SendActivityEnd() error = %v", err)
+	}
+
+	select {
+	case req := <-q.Events():
+		if !req.ActivityEnd {
+			t.Error("expected ActivityEnd = true")
+		}
+		if req.ActivityStart {
+			t.Error("expected ActivityStart = false")
+		}
+		if req.Content != nil || req.RealtimeInput != nil || req.ToolResponse != nil {
+			t.Error("expected only ActivityEnd to be set")
+		}
+	default:
+		t.Fatal("expected a message in the queue")
+	}
+}
+
+func TestSendActivityOnClosedQueue(t *testing.T) {
+	t.Parallel()
+
+	q := NewLiveRequestQueue(10)
+	q.Close()
+
+	if err := q.SendActivityStart(context.Background()); err != ErrQueueClosed {
+		t.Errorf("SendActivityStart on closed queue: got %v, want ErrQueueClosed", err)
+	}
+	if err := q.SendActivityEnd(context.Background()); err != ErrQueueClosed {
+		t.Errorf("SendActivityEnd on closed queue: got %v, want ErrQueueClosed", err)
+	}
+}

--- a/model/gemini/gemini_live.go
+++ b/model/gemini/gemini_live.go
@@ -43,6 +43,14 @@ func (c *geminiLiveConnection) Send(_ context.Context, req *model.LiveRequest) e
 		return c.session.SendToolResponse(genai.LiveToolResponseInput{
 			FunctionResponses: req.ToolResponse,
 		})
+	case req.ActivityStart:
+		return c.session.SendRealtimeInput(genai.LiveRealtimeInput{
+			ActivityStart: &genai.ActivityStart{},
+		})
+	case req.ActivityEnd:
+		return c.session.SendRealtimeInput(genai.LiveRealtimeInput{
+			ActivityEnd: &genai.ActivityEnd{},
+		})
 	case req.RealtimeInput != nil:
 		return c.session.SendRealtimeInput(genai.LiveRealtimeInput{
 			Media: req.RealtimeInput.Media,

--- a/model/llm.go
+++ b/model/llm.go
@@ -93,6 +93,12 @@ type LiveRequest struct {
 	RealtimeInput *genai.LiveRealtimeInput
 	ToolResponse  []*genai.FunctionResponse
 	Close         bool
+	// ActivityStart signals that user activity has begun (manual VAD).
+	// Only valid when automatic activity detection is disabled.
+	ActivityStart bool
+	// ActivityEnd signals that user activity has ended (manual VAD).
+	// Only valid when automatic activity detection is disabled.
+	ActivityEnd bool
 	// TurnComplete controls whether the model should respond after this content.
 	// nil defaults to true (backwards compatible). Set to false when sending
 	// history turns that the model should absorb without responding.

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -1214,3 +1214,78 @@ func TestScenario15_DeferFlushOnConsumerBreak(t *testing.T) {
 		t.Errorf("flushed author = %q, want agent name", persisted[0].Author)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 16: Activity signals flow through the live connection
+// ---------------------------------------------------------------------------
+
+func TestScenario16_ActivitySignals(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 10)
+
+	r, _, _ := setupRunner(t, conn, nil, nil)
+	queue := agent.NewLiveRequestQueue(100)
+
+	// Enqueue activity signals before starting the live session.
+	_ = queue.SendActivityStart(context.Background())
+	_ = queue.SendActivityEnd(context.Background())
+
+	go func() {
+		// Give sender loop time to process queued messages.
+		time.Sleep(100 * time.Millisecond)
+		conn.recvCh <- turnCompleteResponse()
+		time.Sleep(50 * time.Millisecond)
+		queue.Close()
+	}()
+
+	collectEvents(t, r, queue)
+
+	sendLog := conn.SendLog()
+
+	// Verify that ActivityStart and ActivityEnd requests were sent.
+	var gotStart, gotEnd bool
+	for _, req := range sendLog {
+		if req.ActivityStart {
+			gotStart = true
+		}
+		if req.ActivityEnd {
+			gotEnd = true
+		}
+	}
+	if !gotStart {
+		t.Error("expected ActivityStart request in send log")
+	}
+	if !gotEnd {
+		t.Error("expected ActivityEnd request in send log")
+	}
+
+	// Verify ordering: ActivityStart before ActivityEnd.
+	startIdx, endIdx := -1, -1
+	for i, req := range sendLog {
+		if req.ActivityStart && startIdx == -1 {
+			startIdx = i
+		}
+		if req.ActivityEnd && endIdx == -1 {
+			endIdx = i
+		}
+	}
+	if startIdx >= 0 && endIdx >= 0 && startIdx > endIdx {
+		t.Errorf("ActivityStart (idx=%d) should precede ActivityEnd (idx=%d)", startIdx, endIdx)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 17: Activity signals on a closed queue return ErrQueueClosed
+// ---------------------------------------------------------------------------
+
+func TestScenario17_ActivitySignalsClosedQueue(t *testing.T) {
+	queue := agent.NewLiveRequestQueue(10)
+	queue.Close()
+
+	if err := queue.SendActivityStart(context.Background()); err != agent.ErrQueueClosed {
+		t.Errorf("SendActivityStart on closed queue: got %v, want ErrQueueClosed", err)
+	}
+	if err := queue.SendActivityEnd(context.Background()); err != agent.ErrQueueClosed {
+		t.Errorf("SendActivityEnd on closed queue: got %v, want ErrQueueClosed", err)
+	}
+}


### PR DESCRIPTION
> Migrated from https://github.com/dmora/adk-go/pull/22 (original creator: @dmora)
> Original review comments are preserved on the source PR.

---

Resolves #9. Added ActivityStart and ActivityEnd to LiveRequest, and added convenience methods to LiveRequestQueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)