### PR TITLE
feat: task_completed handling in live mode

### DIFF
--- a/agent/run_config.go
+++ b/agent/run_config.go
@@ -48,6 +48,9 @@ type RunConfig struct {
 	OutputAudioTranscription bool
 	ToolCoalesceWindow       time.Duration // default 150ms if zero
 	LiveBufferSize           int           // default 100 if zero
+	// TaskCompletionDelay is the time to wait after a task_completed tool
+	// response before shutting down the live session. Default 1s if zero.
+	TaskCompletionDelay time.Duration
 	// Generation parameters — applied to the live session config when set.
 	ThinkingConfig  *genai.ThinkingConfig
 	Temperature     *float32

--- a/internal/llminternal/base_flow_live.go
+++ b/internal/llminternal/base_flow_live.go
@@ -270,7 +270,7 @@ func (lf *LiveFlow) receiverLoop(
 				return
 			}
 		case <-cs.flushCh:
-			lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, eventCh)
+			lf.flushToolCalls(ctx, invCtx, conn, queue, cs, toolsFuncMap, eventCh)
 		case <-ctx.Done():
 			return
 		}
@@ -328,7 +328,7 @@ func (lf *LiveFlow) processMessage(
 		return
 	}
 
-	lf.flushCoalesceBuffer(ctx, invCtx, conn, cs, toolsFuncMap, eventCh)
+	lf.flushCoalesceBuffer(ctx, invCtx, conn, queue, cs, toolsFuncMap, eventCh)
 
 	isAudio := false
 	if resp.CustomMetadata != nil {
@@ -420,6 +420,7 @@ func (lf *LiveFlow) flushCoalesceBuffer(
 	ctx context.Context,
 	invCtx agent.InvocationContext,
 	conn model.LiveConnection,
+	queue *agent.LiveRequestQueue,
 	cs *coalesceState,
 	toolsFuncMap map[string]toolinternal.FunctionTool,
 	eventCh chan<- eventOrError,
@@ -440,13 +441,14 @@ func (lf *LiveFlow) flushCoalesceBuffer(
 	if empty {
 		return
 	}
-	lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, eventCh)
+	lf.flushToolCalls(ctx, invCtx, conn, queue, cs, toolsFuncMap, eventCh)
 }
 
 func (lf *LiveFlow) flushToolCalls(
 	ctx context.Context,
 	invCtx agent.InvocationContext,
 	conn model.LiveConnection,
+	queue *agent.LiveRequestQueue,
 	cs *coalesceState,
 	toolsFuncMap map[string]toolinternal.FunctionTool,
 	eventCh chan<- eventOrError,
@@ -469,6 +471,19 @@ func (lf *LiveFlow) flushToolCalls(
 		return
 	}
 	lf.emitFunctionResponseEvent(ctx, invCtx, responses, eventCh)
+
+	// Check if any tool response signals task completion.
+	for _, r := range responses {
+		if r.Name == "task_completed" {
+			delay := time.Second
+			if rc := invCtx.RunConfig(); rc != nil && rc.TaskCompletionDelay > 0 {
+				delay = rc.TaskCompletionDelay
+			}
+			time.Sleep(delay)
+			queue.Close()
+			return
+		}
+	}
 }
 
 func (lf *LiveFlow) collectBufferedCalls(cs *coalesceState) map[string]*genai.FunctionCall {

--- a/internal/llminternal/base_flow_live.go
+++ b/internal/llminternal/base_flow_live.go
@@ -479,7 +479,10 @@ func (lf *LiveFlow) flushToolCalls(
 			if rc := invCtx.RunConfig(); rc != nil && rc.TaskCompletionDelay > 0 {
 				delay = rc.TaskCompletionDelay
 			}
-			time.Sleep(delay)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+			}
 			queue.Close()
 			return
 		}

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -1214,3 +1214,139 @@ func TestScenario15_DeferFlushOnConsumerBreak(t *testing.T) {
 		t.Errorf("flushed author = %q, want agent name", persisted[0].Author)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 16: task_completed tool triggers clean shutdown
+// ---------------------------------------------------------------------------
+
+func TestScenario16_TaskCompletedShutdown(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 10)
+
+	taskTool := &mockTool{
+		name:   "task_completed",
+		result: map[string]any{"status": "done"},
+	}
+
+	llm := &mockLiveLLM{conn: conn}
+	a, _ := llmagent.New(llmagent.Config{
+		Name:  "test_agent",
+		Model: llm,
+		Tools: []tool.Tool{taskTool},
+	})
+
+	svc := &mockSessionService{Service: session.InMemoryService()}
+	_, _ = svc.Service.Create(context.Background(), &session.CreateRequest{
+		AppName: "test", UserID: "user1", SessionID: "sess1",
+	})
+
+	r, _ := New(Config{
+		AppName:        "test",
+		Agent:          a,
+		SessionService: svc,
+	})
+
+	queue := agent.NewLiveRequestQueue(100)
+
+	go func() {
+		// Send a function call for task_completed.
+		conn.recvCh <- functionCallResponse("fc1", "task_completed", nil)
+		// Don't close queue — the task_completed handler should do it.
+	}()
+
+	start := time.Now()
+	cfg := agent.RunConfig{
+		ToolCoalesceWindow:  10 * time.Millisecond,
+		TaskCompletionDelay: 100 * time.Millisecond,
+	}
+	var events []*session.Event
+	for ev, err := range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		if err != nil {
+			break
+		}
+		if ev != nil {
+			events = append(events, ev)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// Should have completed (queue closed by task_completed handler).
+	if elapsed > 5*time.Second {
+		t.Errorf("test took %v, expected quick shutdown after task_completed", elapsed)
+	}
+
+	// The task_completed tool should have been called.
+	if taskTool.CallCount() != 1 {
+		t.Errorf("expected task_completed called once, got %d", taskTool.CallCount())
+	}
+
+	// Queue should be closed.
+	select {
+	case <-queue.Done():
+		// ok — queue was closed by the handler.
+	default:
+		t.Error("expected queue to be closed after task_completed")
+	}
+
+	// Connection should be closed.
+	if !conn.WasClosed() {
+		t.Error("expected connection to be closed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 17: task_completed respects context cancellation during delay
+// ---------------------------------------------------------------------------
+
+func TestScenario17_TaskCompletedCancellation(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 10)
+
+	taskTool := &mockTool{
+		name:   "task_completed",
+		result: map[string]any{"status": "done"},
+	}
+
+	llm := &mockLiveLLM{conn: conn}
+	a, _ := llmagent.New(llmagent.Config{
+		Name:  "test_agent",
+		Model: llm,
+		Tools: []tool.Tool{taskTool},
+	})
+
+	svc := &mockSessionService{Service: session.InMemoryService()}
+	_, _ = svc.Service.Create(context.Background(), &session.CreateRequest{
+		AppName: "test", UserID: "user1", SessionID: "sess1",
+	})
+
+	r, _ := New(Config{
+		AppName:        "test",
+		Agent:          a,
+		SessionService: svc,
+	})
+
+	queue := agent.NewLiveRequestQueue(100)
+	// Cancel the context quickly — should interrupt the delay.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		conn.recvCh <- functionCallResponse("fc1", "task_completed", nil)
+	}()
+
+	start := time.Now()
+	cfg := agent.RunConfig{
+		ToolCoalesceWindow:  10 * time.Millisecond,
+		TaskCompletionDelay: 10 * time.Second, // Very long delay — should be cancelled.
+	}
+	for ev, err := range r.RunLive(ctx, "user1", "sess1", queue, cfg) {
+		_ = ev
+		_ = err
+	}
+	elapsed := time.Since(start)
+
+	// Should finish quickly due to context cancellation, not wait 10s.
+	if elapsed > 3*time.Second {
+		t.Errorf("test took %v, expected context cancellation to interrupt delay", elapsed)
+	}
+}


### PR DESCRIPTION
> Migrated from https://github.com/dmora/adk-go/pull/23 (original creator: @dmora)
> Original review comments are preserved on the source PR.

---

Resolves #6. Detected task_completed function responses to gracefully close the queue and end sequential agent turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)