### PR TITLE
feat: auto-enable transcription for multi-agent live sessions

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -318,6 +318,16 @@ func (r *Runner) RunLive(
 	cfg agent.RunConfig,
 ) iter.Seq2[*session.Event, error] {
 	cfg.StreamingMode = agent.StreamingModeBidi
+
+	// Auto-enable transcription for multi-agent live sessions so that
+	// sub-agents can consume text representations of audio turns.
+	if len(r.rootAgent.SubAgents()) > 0 && !cfg.InputAudioTranscription {
+		cfg.InputAudioTranscription = true
+	}
+	if len(r.rootAgent.SubAgents()) > 0 && !cfg.OutputAudioTranscription && hasAudioModality(cfg.ResponseModalities) {
+		cfg.OutputAudioTranscription = true
+	}
+
 	return func(yield func(*session.Event, error) bool) {
 		resp, err := r.sessionService.Get(ctx, &session.GetRequest{
 			AppName:   r.appName,
@@ -595,4 +605,13 @@ func findAgent(curAgent agent.Agent, targetName string) agent.Agent {
 		}
 	}
 	return nil
+}
+
+func hasAudioModality(modalities []genai.Modality) bool {
+	for _, m := range modalities {
+		if m == genai.ModalityAudio {
+			return true
+		}
+	}
+	return false
 }

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -197,7 +197,9 @@ func (t *mockTool) Calls() []mockToolCall {
 // ---------------------------------------------------------------------------
 
 type mockLiveLLM struct {
-	conn model.LiveConnection
+	conn        model.LiveConnection
+	mu          sync.Mutex
+	lastRequest *model.LLMRequest
 }
 
 func (m *mockLiveLLM) Name() string { return "mock-live" }
@@ -206,8 +208,17 @@ func (m *mockLiveLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ 
 	return func(yield func(*model.LLMResponse, error) bool) {}
 }
 
-func (m *mockLiveLLM) ConnectLive(_ context.Context, _ *model.LLMRequest) (model.LiveConnection, error) {
+func (m *mockLiveLLM) ConnectLive(_ context.Context, req *model.LLMRequest) (model.LiveConnection, error) {
+	m.mu.Lock()
+	m.lastRequest = req
+	m.mu.Unlock()
 	return m.conn, nil
+}
+
+func (m *mockLiveLLM) LastRequest() *model.LLMRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastRequest
 }
 
 var _ model.LiveCapableLLM = (*mockLiveLLM)(nil)
@@ -1219,63 +1230,100 @@ func TestScenario15_DeferFlushOnConsumerBreak(t *testing.T) {
 // Scenario 16: Auto-enable transcription for multi-agent live sessions
 // ---------------------------------------------------------------------------
 
-func TestScenario16_AutoEnableTranscriptionMultiAgent(t *testing.T) {
-	conn := newMockLiveConnection()
-	conn.recvResponses = []*model.LLMResponse{
-		turnCompleteResponse(),
-	}
-
-	llm := &mockLiveLLM{conn: conn}
-
+func setupMultiAgentRunner(t *testing.T, llm *mockLiveLLM) *Runner {
+	t.Helper()
 	subAgent, _ := llmagent.New(llmagent.Config{
 		Name:  "sub_agent",
 		Model: llm,
 	})
-
 	rootAgent, _ := llmagent.New(llmagent.Config{
 		Name:      "root_agent",
 		Model:     llm,
 		SubAgents: []agent.Agent{subAgent},
 	})
-
 	svc := &mockSessionService{Service: session.InMemoryService()}
 	_, _ = svc.Service.Create(context.Background(), &session.CreateRequest{
 		AppName: "test", UserID: "user1", SessionID: "sess1",
 	})
-
 	r, _ := New(Config{
 		AppName:        "test",
 		Agent:          rootAgent,
 		SessionService: svc,
 	})
+	return r
+}
 
-	queue := agent.NewLiveRequestQueue(100)
-	queue.Close()
-
+func TestScenario16_AutoEnableTranscriptionMultiAgent(t *testing.T) {
 	t.Run("input_transcription_auto_enabled", func(t *testing.T) {
+		conn := newMockLiveConnection()
+		conn.recvResponses = []*model.LLMResponse{turnCompleteResponse()}
+		llm := &mockLiveLLM{conn: conn}
+		r := setupMultiAgentRunner(t, llm)
+		queue := agent.NewLiveRequestQueue(100)
+		queue.Close()
+
 		cfg := agent.RunConfig{}
 		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
 		}
-		// RunLive should have auto-enabled InputAudioTranscription.
-		// We verify indirectly: since RunLive mutates the cfg copy, we check
-		// that the live connect config sent to the model has transcription enabled.
-		// The mock doesn't expose this directly, so we just verify the build passes
-		// and the logic is exercised without errors.
+
+		req := llm.LastRequest()
+		if req == nil || req.LiveConfig == nil {
+			t.Fatal("expected ConnectLive to be called with a LiveConfig")
+		}
+		if req.LiveConfig.InputAudioTranscription == nil {
+			t.Error("expected InputAudioTranscription to be auto-enabled for multi-agent")
+		}
 	})
 
 	t.Run("output_transcription_auto_enabled_with_audio", func(t *testing.T) {
+		conn := newMockLiveConnection()
+		conn.recvResponses = []*model.LLMResponse{turnCompleteResponse()}
+		llm := &mockLiveLLM{conn: conn}
+		r := setupMultiAgentRunner(t, llm)
+		queue := agent.NewLiveRequestQueue(100)
+		queue.Close()
+
 		cfg := agent.RunConfig{
 			ResponseModalities: []genai.Modality{genai.ModalityAudio},
 		}
 		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
 		}
+
+		req := llm.LastRequest()
+		if req == nil || req.LiveConfig == nil {
+			t.Fatal("expected ConnectLive to be called with a LiveConfig")
+		}
+		if req.LiveConfig.InputAudioTranscription == nil {
+			t.Error("expected InputAudioTranscription to be auto-enabled for multi-agent")
+		}
+		if req.LiveConfig.OutputAudioTranscription == nil {
+			t.Error("expected OutputAudioTranscription to be auto-enabled for multi-agent with audio modality")
+		}
 	})
 
 	t.Run("output_transcription_not_enabled_without_audio", func(t *testing.T) {
+		conn := newMockLiveConnection()
+		conn.recvResponses = []*model.LLMResponse{turnCompleteResponse()}
+		llm := &mockLiveLLM{conn: conn}
+		r := setupMultiAgentRunner(t, llm)
+		queue := agent.NewLiveRequestQueue(100)
+		queue.Close()
+
 		cfg := agent.RunConfig{
 			ResponseModalities: []genai.Modality{genai.ModalityText},
 		}
 		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		}
+
+		req := llm.LastRequest()
+		if req == nil || req.LiveConfig == nil {
+			t.Fatal("expected ConnectLive to be called with a LiveConfig")
+		}
+		if req.LiveConfig.InputAudioTranscription == nil {
+			t.Error("expected InputAudioTranscription to be auto-enabled for multi-agent")
+		}
+		if req.LiveConfig.OutputAudioTranscription != nil {
+			t.Error("expected OutputAudioTranscription to NOT be auto-enabled without audio modality")
 		}
 	})
 }

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -1214,3 +1214,92 @@ func TestScenario15_DeferFlushOnConsumerBreak(t *testing.T) {
 		t.Errorf("flushed author = %q, want agent name", persisted[0].Author)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 16: Auto-enable transcription for multi-agent live sessions
+// ---------------------------------------------------------------------------
+
+func TestScenario16_AutoEnableTranscriptionMultiAgent(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		turnCompleteResponse(),
+	}
+
+	llm := &mockLiveLLM{conn: conn}
+
+	subAgent, _ := llmagent.New(llmagent.Config{
+		Name:  "sub_agent",
+		Model: llm,
+	})
+
+	rootAgent, _ := llmagent.New(llmagent.Config{
+		Name:      "root_agent",
+		Model:     llm,
+		SubAgents: []agent.Agent{subAgent},
+	})
+
+	svc := &mockSessionService{Service: session.InMemoryService()}
+	_, _ = svc.Service.Create(context.Background(), &session.CreateRequest{
+		AppName: "test", UserID: "user1", SessionID: "sess1",
+	})
+
+	r, _ := New(Config{
+		AppName:        "test",
+		Agent:          rootAgent,
+		SessionService: svc,
+	})
+
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	t.Run("input_transcription_auto_enabled", func(t *testing.T) {
+		cfg := agent.RunConfig{}
+		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		}
+		// RunLive should have auto-enabled InputAudioTranscription.
+		// We verify indirectly: since RunLive mutates the cfg copy, we check
+		// that the live connect config sent to the model has transcription enabled.
+		// The mock doesn't expose this directly, so we just verify the build passes
+		// and the logic is exercised without errors.
+	})
+
+	t.Run("output_transcription_auto_enabled_with_audio", func(t *testing.T) {
+		cfg := agent.RunConfig{
+			ResponseModalities: []genai.Modality{genai.ModalityAudio},
+		}
+		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		}
+	})
+
+	t.Run("output_transcription_not_enabled_without_audio", func(t *testing.T) {
+		cfg := agent.RunConfig{
+			ResponseModalities: []genai.Modality{genai.ModalityText},
+		}
+		for range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		}
+	})
+}
+
+func TestHasAudioModality(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		modalities []genai.Modality
+		want       bool
+	}{
+		{"nil", nil, false},
+		{"empty", []genai.Modality{}, false},
+		{"text_only", []genai.Modality{genai.ModalityText}, false},
+		{"audio_only", []genai.Modality{genai.ModalityAudio}, true},
+		{"text_and_audio", []genai.Modality{genai.ModalityText, genai.ModalityAudio}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasAudioModality(tt.modalities); got != tt.want {
+				t.Errorf("hasAudioModality(%v) = %v, want %v", tt.modalities, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Migrated from https://github.com/dmora/adk-go/pull/24 (original creator: @dmora)
> Original review comments are preserved on the source PR.

---

Resolves #5. Automatically enabled InputAudioTranscription and OutputAudioTranscription when an agent has sub-agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)