### PR TITLE
feat: Compositional Function Calling (CFC) via live path

### DIFF
--- a/agent/run_config.go
+++ b/agent/run_config.go
@@ -41,6 +41,9 @@ type RunConfig struct {
 	// If true, ADK runner will save each part of the user input that is a blob
 	// (e.g., images, files) as an artifact.
 	SaveInputBlobsAsArtifacts bool
+	// SupportCFC enables Compositional Function Calling by redirecting the
+	// text generation path through the Live API. Only supported for gemini-2 models.
+	SupportCFC bool
 	// Live-specific configuration
 	ResponseModalities       []genai.Modality
 	SpeechConfig             *genai.SpeechConfig

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -176,6 +176,24 @@ func (f *Flow) runCFC(ctx agent.InvocationContext) iter.Seq2[*session.Event, err
 			liveCfg.Tools = []*genai.Tool{{FunctionDeclarations: decls}}
 		}
 
+		// Execute BeforeModelCallbacks before starting the live flow.
+		// AfterModelCallbacks are not supported in CFC mode because the
+		// live flow yields a stream of events rather than a single response.
+		for _, callback := range f.BeforeModelCallbacks {
+			cctx := icontext.NewCallbackContextWithDelta(ctx, nil, nil)
+			cbResp, cbErr := callback(cctx, req)
+			if cbResp != nil || cbErr != nil {
+				ev := session.NewEvent(ctx.InvocationID())
+				ev.Author = ctx.Agent().Name()
+				ev.Branch = ctx.Branch()
+				if cbResp != nil {
+					ev.LLMResponse = *cbResp
+				}
+				yield(ev, cbErr)
+				return
+			}
+		}
+
 		req.LiveConfig = liveCfg
 		conn, err := liveLLM.ConnectLive(ctx, req)
 		if err != nil {
@@ -183,10 +201,16 @@ func (f *Flow) runCFC(ctx agent.InvocationContext) iter.Seq2[*session.Event, err
 			return
 		}
 
-		// Create a temporary queue, seed it with the user content, and close
-		// it so the live flow processes exactly one turn.
+		// Create a temporary queue, seed it with the preprocessed contents,
+		// and close it so the live flow processes exactly one turn.
+		// Fall back to UserContent if preprocessing didn't populate Contents
+		// (e.g. session has no prior events yet).
 		queue := agent.NewLiveRequestQueue(16)
-		if ctx.UserContent() != nil {
+		if len(req.Contents) > 0 {
+			for _, content := range req.Contents {
+				_ = queue.Send(context.Background(), &model.LiveRequest{Content: content})
+			}
+		} else if ctx.UserContent() != nil {
 			_ = queue.Send(context.Background(), &model.LiveRequest{Content: ctx.UserContent()})
 		}
 		queue.Close()

--- a/internal/llminternal/base_flow.go
+++ b/internal/llminternal/base_flow.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/genai"
@@ -95,6 +96,9 @@ var (
 )
 
 func (f *Flow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+	if rc := ctx.RunConfig(); rc != nil && rc.SupportCFC {
+		return f.runCFC(ctx)
+	}
 	return func(yield func(*session.Event, error) bool) {
 		for {
 			var lastEvent *session.Event
@@ -116,6 +120,93 @@ func (f *Flow) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, error]
 				// We may have reached max token limit during streaming mode.
 				// TODO: handle Partial response in model level. CL 781377328
 				yield(nil, fmt.Errorf("TODO: last event is not final"))
+				return
+			}
+		}
+	}
+}
+
+// runCFC redirects the text generation path through the Live API to enable
+// Compositional Function Calling. The model handles tool calls internally
+// within a single turn.
+func (f *Flow) runCFC(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		if !strings.Contains(f.Model.Name(), "gemini-2") {
+			yield(nil, fmt.Errorf("compositional function calling (CFC) is only supported for gemini-2 models"))
+			return
+		}
+
+		liveLLM, ok := f.Model.(model.LiveCapableLLM)
+		if !ok {
+			yield(nil, fmt.Errorf("model %q does not support live connections required for CFC", f.Model.Name()))
+			return
+		}
+
+		// Build LLM request via the normal preprocessing pipeline so that
+		// instructions, tools, and contents are resolved.
+		req := &model.LLMRequest{Model: f.Model.Name()}
+		for _, err := range f.preprocess(ctx, req) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+		}
+
+		// Translate the preprocessed text-path request into a LiveConnectConfig.
+		liveCfg := &genai.LiveConnectConfig{
+			ResponseModalities: []genai.Modality{genai.ModalityText},
+		}
+		if req.Config != nil && req.Config.SystemInstruction != nil {
+			liveCfg.SystemInstruction = req.Config.SystemInstruction
+		}
+
+		// Convert tools from the preprocessed map to live tool declarations.
+		var decls []*genai.FunctionDeclaration
+		for _, v := range req.Tools {
+			type declarable interface {
+				Declaration() *genai.FunctionDeclaration
+			}
+			if dt, ok := v.(declarable); ok {
+				if d := dt.Declaration(); d != nil {
+					decls = append(decls, d)
+				}
+			}
+		}
+		if len(decls) > 0 {
+			liveCfg.Tools = []*genai.Tool{{FunctionDeclarations: decls}}
+		}
+
+		req.LiveConfig = liveCfg
+		conn, err := liveLLM.ConnectLive(ctx, req)
+		if err != nil {
+			yield(nil, fmt.Errorf("CFC: failed to connect live: %w", err))
+			return
+		}
+
+		// Create a temporary queue, seed it with the user content, and close
+		// it so the live flow processes exactly one turn.
+		queue := agent.NewLiveRequestQueue(16)
+		if ctx.UserContent() != nil {
+			_ = queue.Send(context.Background(), &model.LiveRequest{Content: ctx.UserContent()})
+		}
+		queue.Close()
+
+		coalesceWindow := 150 * time.Millisecond
+		if rc := ctx.RunConfig(); rc != nil && rc.ToolCoalesceWindow > 0 {
+			coalesceWindow = rc.ToolCoalesceWindow
+		}
+
+		lf := &LiveFlow{
+			Model:                f.Model,
+			Tools:                f.Tools,
+			BeforeToolCallbacks:  f.BeforeToolCallbacks,
+			AfterToolCallbacks:   f.AfterToolCallbacks,
+			OnToolErrorCallbacks: f.OnToolErrorCallbacks,
+			CoalesceWindow:       coalesceWindow,
+		}
+
+		for ev, err := range lf.RunLive(ctx, conn, queue) {
+			if !yield(ev, err) {
 				return
 			}
 		}

--- a/internal/llminternal/base_flow_test.go
+++ b/internal/llminternal/base_flow_test.go
@@ -15,12 +15,18 @@
 package llminternal
 
 import (
+	"context"
 	"errors"
+	"io"
+	"iter"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genai"
 
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/internal/agent/runconfig"
 	icontext "google.golang.org/adk/internal/context"
 	"google.golang.org/adk/internal/toolinternal"
 	"google.golang.org/adk/model"
@@ -573,5 +579,206 @@ func TestMergeEventActions(t *testing.T) {
 				t.Errorf("mergeEventActions() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CFC (Compositional Function Calling) tests
+// ---------------------------------------------------------------------------
+
+// cfcMockLLM is a basic LLM that does NOT implement LiveCapableLLM.
+type cfcMockLLM struct {
+	name string
+}
+
+func (m *cfcMockLLM) Name() string { return m.name }
+
+func (m *cfcMockLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {}
+}
+
+// cfcMockLiveLLM implements LiveCapableLLM.
+type cfcMockLiveLLM struct {
+	name    string
+	conn    *cfcMockLiveConn
+	mu      sync.Mutex
+	lastReq *model.LLMRequest
+}
+
+func (m *cfcMockLiveLLM) Name() string { return m.name }
+
+func (m *cfcMockLiveLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {}
+}
+
+func (m *cfcMockLiveLLM) ConnectLive(_ context.Context, req *model.LLMRequest) (model.LiveConnection, error) {
+	m.mu.Lock()
+	m.lastReq = req
+	m.mu.Unlock()
+	return m.conn, nil
+}
+
+var _ model.LiveCapableLLM = (*cfcMockLiveLLM)(nil)
+
+// cfcMockLiveConn records sent messages and returns a turn-complete then EOF.
+type cfcMockLiveConn struct {
+	mu      sync.Mutex
+	sent    []*model.LiveRequest
+	recvIdx int
+}
+
+func (c *cfcMockLiveConn) Send(_ context.Context, req *model.LiveRequest) error {
+	c.mu.Lock()
+	c.sent = append(c.sent, req)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *cfcMockLiveConn) Receive(_ context.Context) (*model.LLMResponse, error) {
+	c.mu.Lock()
+	idx := c.recvIdx
+	c.recvIdx++
+	c.mu.Unlock()
+	if idx == 0 {
+		return &model.LLMResponse{TurnComplete: true}, nil
+	}
+	return nil, io.EOF
+}
+
+func (c *cfcMockLiveConn) Close() error { return nil }
+
+func (c *cfcMockLiveConn) Sent() []*model.LiveRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make([]*model.LiveRequest, len(c.sent))
+	copy(cp, c.sent)
+	return cp
+}
+
+// cfcMockAgent satisfies agent.Agent for CFC tests by embedding the interface.
+type cfcMockAgent struct {
+	agent.Agent
+	name string
+}
+
+func (a *cfcMockAgent) Name() string { return a.name }
+
+func TestRunCFC_ErrorNonGemini2Model(t *testing.T) {
+	f := &Flow{
+		Model:             &cfcMockLLM{name: "gpt-4"},
+		RequestProcessors: DefaultRequestProcessors,
+	}
+	ctx := runconfig.ToContext(context.Background(), &runconfig.RunConfig{})
+	invCtx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+		Agent:     &cfcMockAgent{name: "test"},
+		RunConfig: &agent.RunConfig{SupportCFC: true},
+	})
+
+	var errs []error
+	for _, err := range f.Run(invCtx) {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected error for non-gemini-2 model")
+	}
+	if errs[0].Error() != "compositional function calling (CFC) is only supported for gemini-2 models" {
+		t.Errorf("unexpected error: %v", errs[0])
+	}
+}
+
+func TestRunCFC_ErrorNotLiveCapable(t *testing.T) {
+	f := &Flow{
+		Model:             &cfcMockLLM{name: "gemini-2-flash"},
+		RequestProcessors: DefaultRequestProcessors,
+	}
+	ctx := runconfig.ToContext(context.Background(), &runconfig.RunConfig{})
+	invCtx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+		Agent:     &cfcMockAgent{name: "test"},
+		RunConfig: &agent.RunConfig{SupportCFC: true},
+	})
+
+	var errs []error
+	for _, err := range f.Run(invCtx) {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected error for non-LiveCapable model")
+	}
+	want := `model "gemini-2-flash" does not support live connections required for CFC`
+	if errs[0].Error() != want {
+		t.Errorf("unexpected error: %v", errs[0])
+	}
+}
+
+func TestRunCFC_SuccessfulRedirect(t *testing.T) {
+	conn := &cfcMockLiveConn{}
+	llm := &cfcMockLiveLLM{name: "gemini-2.0-flash", conn: conn}
+	// Use a minimal ContentsRequestProcessor so req.Contents gets populated
+	// from session events, bypassing processors that require a real LLMAgent.
+	f := &Flow{
+		Model:             llm,
+		RequestProcessors: []func(agent.InvocationContext, *model.LLMRequest, *Flow) iter.Seq2[*session.Event, error]{ContentsRequestProcessor},
+	}
+	svc := session.InMemoryService()
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: "test", UserID: "user1", SessionID: "sess1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := runconfig.ToContext(context.Background(), &runconfig.RunConfig{})
+	invCtx := icontext.NewInvocationContext(ctx, icontext.InvocationContextParams{
+		Agent:       &cfcMockAgent{name: "test"},
+		RunConfig:   &agent.RunConfig{SupportCFC: true},
+		UserContent: genai.NewContentFromText("Hello", "user"),
+		Session:     resp.Session,
+	})
+
+	var events []*session.Event
+	var errs []error
+	for ev, err := range f.Run(invCtx) {
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if ev != nil {
+			events = append(events, ev)
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	// LiveFlow should have produced at least a turn-complete event.
+	if len(events) == 0 {
+		t.Fatal("expected at least one event from CFC live flow")
+	}
+
+	// Verify ConnectLive was called with a LiveConfig.
+	llm.mu.Lock()
+	req := llm.lastReq
+	llm.mu.Unlock()
+	if req == nil || req.LiveConfig == nil {
+		t.Fatal("expected ConnectLive to be called with LiveConfig")
+	}
+	if len(req.LiveConfig.ResponseModalities) == 0 || req.LiveConfig.ResponseModalities[0] != genai.ModalityText {
+		t.Error("expected text-only response modalities in CFC mode")
+	}
+
+	// Verify preprocessed contents were sent to the live connection
+	// (not raw UserContent).
+	sent := conn.Sent()
+	foundContent := false
+	for _, s := range sent {
+		if s.Content != nil {
+			foundContent = true
+		}
+	}
+	if !foundContent {
+		t.Error("expected preprocessed contents to be sent to the live connection")
 	}
 }


### PR DESCRIPTION
> Migrated from https://github.com/dmora/adk-go/pull/25 (original creator: @dmora)
> Original review comments are preserved on the source PR.

---

Resolves #10. Route standard text flow through the live connection when SupportCFC is enabled for gemini-2 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)