### PR TITLE
feat: active streaming tools — duplicate live audio to parallel tool queues

### DIFF
--- a/agent/active_streaming_tool.go
+++ b/agent/active_streaming_tool.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "context"
+
+// StreamingTool is a tool that receives a continuous stream of live requests
+// (e.g. audio chunks) via its own LiveRequestQueue.
+type StreamingTool interface {
+	// Run starts the streaming tool. It blocks until ctx is cancelled or the
+	// stream queue is closed. Implementations should select on both ctx.Done()
+	// and stream.Events() / stream.Done().
+	Run(ctx context.Context, stream *LiveRequestQueue)
+}
+
+// ActiveStreamingTool tracks a running StreamingTool instance. The sender loop
+// fans out each incoming live request to Stream so the tool receives a copy of
+// the audio/realtime data in parallel with the model connection.
+type ActiveStreamingTool struct {
+	// Name identifies this streaming tool (for logging/diagnostics).
+	Name string
+	// Stream is the tool's private LiveRequestQueue that receives duplicated
+	// live requests from the sender loop.
+	Stream *LiveRequestQueue
+	// Cancel stops the tool's goroutine.
+	Cancel context.CancelFunc
+}
+
+// Close cancels the tool's context and closes its stream queue.
+func (a *ActiveStreamingTool) Close() {
+	if a.Cancel != nil {
+		a.Cancel()
+	}
+	if a.Stream != nil {
+		a.Stream.Close()
+	}
+}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -434,12 +434,13 @@ type invocationContext struct {
 	memory    Memory
 	session   session.Session
 
-	invocationID     string
-	branch           string
-	userContent      *genai.Content
-	runConfig        *RunConfig
-	endInvocation    bool
-	liveRequestQueue *LiveRequestQueue
+	invocationID         string
+	branch               string
+	userContent          *genai.Content
+	runConfig            *RunConfig
+	endInvocation        bool
+	liveRequestQueue     *LiveRequestQueue
+	activeStreamingTools []*ActiveStreamingTool
 }
 
 func (c *invocationContext) Agent() Agent {
@@ -476,6 +477,14 @@ func (c *invocationContext) RunConfig() *RunConfig {
 
 func (c *invocationContext) LiveRequestQueue() *LiveRequestQueue {
 	return c.liveRequestQueue
+}
+
+func (c *invocationContext) AddActiveStreamingTool(tool *ActiveStreamingTool) {
+	c.activeStreamingTools = append(c.activeStreamingTools, tool)
+}
+
+func (c *invocationContext) ActiveStreamingTools() []*ActiveStreamingTool {
+	return c.activeStreamingTools
 }
 
 func (c *invocationContext) EndInvocation() {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"sync"
 
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/genai"
@@ -440,6 +441,7 @@ type invocationContext struct {
 	runConfig            *RunConfig
 	endInvocation        bool
 	liveRequestQueue     *LiveRequestQueue
+	streamingMu          sync.Mutex
 	activeStreamingTools []*ActiveStreamingTool
 }
 
@@ -480,11 +482,17 @@ func (c *invocationContext) LiveRequestQueue() *LiveRequestQueue {
 }
 
 func (c *invocationContext) AddActiveStreamingTool(tool *ActiveStreamingTool) {
+	c.streamingMu.Lock()
 	c.activeStreamingTools = append(c.activeStreamingTools, tool)
+	c.streamingMu.Unlock()
 }
 
 func (c *invocationContext) ActiveStreamingTools() []*ActiveStreamingTool {
-	return c.activeStreamingTools
+	c.streamingMu.Lock()
+	cp := make([]*ActiveStreamingTool, len(c.activeStreamingTools))
+	copy(cp, c.activeStreamingTools)
+	c.streamingMu.Unlock()
+	return cp
 }
 
 func (c *invocationContext) EndInvocation() {
@@ -496,9 +504,21 @@ func (c *invocationContext) Ended() bool {
 }
 
 func (c *invocationContext) WithContext(ctx context.Context) InvocationContext {
-	newCtx := *c
-	newCtx.Context = ctx
-	return &newCtx
+	// Copy fields explicitly to avoid copying the sync.Mutex.
+	return &invocationContext{
+		Context:              ctx,
+		agent:                c.agent,
+		artifacts:            c.artifacts,
+		memory:               c.memory,
+		session:              c.session,
+		invocationID:         c.invocationID,
+		branch:               c.branch,
+		userContent:          c.userContent,
+		runConfig:            c.runConfig,
+		endInvocation:        c.endInvocation,
+		liveRequestQueue:     c.liveRequestQueue,
+		activeStreamingTools: c.activeStreamingTools,
+	}
 }
 
 func pluginManagerFromContext(ctx context.Context) pluginManager {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -274,7 +274,7 @@ func TestWithContext(t *testing.T) {
 	if got.Value(key) != val {
 		t.Errorf("WithContext() did not update context")
 	}
-	if diff := cmp.Diff(inv, got, cmp.AllowUnexported(invocationContext{}), cmpopts.IgnoreFields(invocationContext{}, "Context")); diff != "" {
+	if diff := cmp.Diff(inv, got, cmp.AllowUnexported(invocationContext{}), cmpopts.IgnoreFields(invocationContext{}, "Context", "streamingMu")); diff != "" {
 		t.Errorf("WithContext() params mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/agent/context.go
+++ b/agent/context.go
@@ -94,6 +94,13 @@ type InvocationContext interface {
 	// Returns nil if not in live mode.
 	LiveRequestQueue() *LiveRequestQueue
 
+	// AddActiveStreamingTool registers a streaming tool that will receive
+	// duplicated live requests from the sender loop.
+	AddActiveStreamingTool(tool *ActiveStreamingTool)
+
+	// ActiveStreamingTools returns all registered active streaming tools.
+	ActiveStreamingTools() []*ActiveStreamingTool
+
 	// EndInvocation ends the current invocation. This stops any planned agent
 	// calls.
 	EndInvocation()

--- a/internal/configurable/conformance/replayplugin/replay_plugin_test.go
+++ b/internal/configurable/conformance/replayplugin/replay_plugin_test.go
@@ -401,6 +401,8 @@ func (m *MockInvocationContext) EndInvocation()                                 
 func (m *MockInvocationContext) Ended() bool                                             { return false }
 func (m *MockInvocationContext) WithContext(ctx context.Context) agent.InvocationContext { return m }
 func (m *MockInvocationContext) LiveRequestQueue() *agent.LiveRequestQueue               { return nil }
+func (m *MockInvocationContext) AddActiveStreamingTool(_ *agent.ActiveStreamingTool)     {}
+func (m *MockInvocationContext) ActiveStreamingTools() []*agent.ActiveStreamingTool      { return nil }
 func (m *MockInvocationContext) Value(key any) any                                       { return nil }
 func (m *MockInvocationContext) Deadline() (deadline time.Time, ok bool)                 { return time.Time{}, false }
 func (m *MockInvocationContext) Done() <-chan struct{}                                   { return nil }

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -60,7 +60,7 @@ func TestWithContext(t *testing.T) {
 	if got.Value(key) != val {
 		t.Errorf("WithContext() did not update context")
 	}
-	if diff := cmp.Diff(inv, got, cmp.AllowUnexported(InvocationContext{}), cmpopts.IgnoreFields(InvocationContext{}, "Context")); diff != "" {
+	if diff := cmp.Diff(inv, got, cmp.AllowUnexported(InvocationContext{}), cmpopts.IgnoreFields(InvocationContext{}, "Context", "streamingMu")); diff != "" {
 		t.Errorf("WithContext() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -32,11 +32,12 @@ type InvocationContextParams struct {
 	Branch string
 	Agent  agent.Agent
 
-	UserContent      *genai.Content
-	RunConfig        *agent.RunConfig
-	EndInvocation    bool
-	InvocationID     string
-	LiveRequestQueue *agent.LiveRequestQueue
+	UserContent          *genai.Content
+	RunConfig            *agent.RunConfig
+	EndInvocation        bool
+	InvocationID         string
+	LiveRequestQueue     *agent.LiveRequestQueue
+	ActiveStreamingTools []*agent.ActiveStreamingTool
 }
 
 func NewInvocationContext(ctx context.Context, params InvocationContextParams) agent.InvocationContext {
@@ -89,6 +90,14 @@ func (c *InvocationContext) RunConfig() *agent.RunConfig {
 
 func (c *InvocationContext) LiveRequestQueue() *agent.LiveRequestQueue {
 	return c.params.LiveRequestQueue
+}
+
+func (c *InvocationContext) AddActiveStreamingTool(tool *agent.ActiveStreamingTool) {
+	c.params.ActiveStreamingTools = append(c.params.ActiveStreamingTools, tool)
+}
+
+func (c *InvocationContext) ActiveStreamingTools() []*agent.ActiveStreamingTool {
+	return c.params.ActiveStreamingTools
 }
 
 func (c *InvocationContext) EndInvocation() {

--- a/internal/context/invocation_context.go
+++ b/internal/context/invocation_context.go
@@ -16,6 +16,7 @@ package context
 
 import (
 	"context"
+	"sync"
 
 	"github.com/google/uuid"
 	"google.golang.org/genai"
@@ -53,7 +54,8 @@ func NewInvocationContext(ctx context.Context, params InvocationContextParams) a
 type InvocationContext struct {
 	context.Context
 
-	params InvocationContextParams
+	params      InvocationContextParams
+	streamingMu sync.Mutex
 }
 
 func (c *InvocationContext) Artifacts() agent.Artifacts {
@@ -93,11 +95,17 @@ func (c *InvocationContext) LiveRequestQueue() *agent.LiveRequestQueue {
 }
 
 func (c *InvocationContext) AddActiveStreamingTool(tool *agent.ActiveStreamingTool) {
+	c.streamingMu.Lock()
 	c.params.ActiveStreamingTools = append(c.params.ActiveStreamingTools, tool)
+	c.streamingMu.Unlock()
 }
 
 func (c *InvocationContext) ActiveStreamingTools() []*agent.ActiveStreamingTool {
-	return c.params.ActiveStreamingTools
+	c.streamingMu.Lock()
+	cp := make([]*agent.ActiveStreamingTool, len(c.params.ActiveStreamingTools))
+	copy(cp, c.params.ActiveStreamingTools)
+	c.streamingMu.Unlock()
+	return cp
 }
 
 func (c *InvocationContext) EndInvocation() {
@@ -109,9 +117,10 @@ func (c *InvocationContext) Ended() bool {
 }
 
 func (c *InvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
-	newCtx := *c
-	newCtx.Context = ctx
-	return &newCtx
+	return &InvocationContext{
+		Context: ctx,
+		params:  c.params,
+	}
 }
 
 var _ agent.InvocationContext = (*InvocationContext)(nil)

--- a/internal/llminternal/base_flow_live.go
+++ b/internal/llminternal/base_flow_live.go
@@ -188,10 +188,20 @@ func (lf *LiveFlow) senderLoop(
 	queue *agent.LiveRequestQueue,
 	eventCh chan<- eventOrError,
 ) {
+	// Ensure all active streaming tools are closed on every exit path.
+	defer func() {
+		for _, st := range invCtx.ActiveStreamingTools() {
+			st.Close()
+		}
+	}()
+
 	fanOut := func(req *model.LiveRequest) {
 		for _, st := range invCtx.ActiveStreamingTools() {
-			// Best-effort: skip if the tool's queue is closed or full.
-			_ = st.Stream.Send(ctx, req)
+			// Non-blocking: fire-and-forget goroutine so a full tool
+			// queue cannot stall the main sender loop.
+			go func(s *agent.ActiveStreamingTool, r *model.LiveRequest) {
+				_ = s.Stream.Send(ctx, r)
+			}(st, req)
 		}
 	}
 
@@ -214,17 +224,10 @@ func (lf *LiveFlow) senderLoop(
 					}
 					fanOut(req)
 				default:
-					// Close all active streaming tools on shutdown.
-					for _, st := range invCtx.ActiveStreamingTools() {
-						st.Close()
-					}
 					return
 				}
 			}
 		case <-ctx.Done():
-			for _, st := range invCtx.ActiveStreamingTools() {
-				st.Close()
-			}
 			return
 		}
 	}

--- a/internal/llminternal/base_flow_live.go
+++ b/internal/llminternal/base_flow_live.go
@@ -107,7 +107,7 @@ func (lf *LiveFlow) RunLive(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			lf.senderLoop(cancelCtx, conn, queue, eventCh)
+			lf.senderLoop(cancelCtx, ctx, conn, queue, eventCh)
 			// Close connection when sender is done (queue closed or error).
 			// This unblocks the receiver's conn.Receive without cancelling
 			// the context used by in-flight tool calls.
@@ -178,14 +178,23 @@ func (lf *LiveFlow) sendHistory(
 	return nil
 }
 
-// senderLoop forwards queue messages to the live connection.
+// senderLoop forwards queue messages to the live connection and fans out
+// each request to any active streaming tools registered on the invocation context.
 // On queue.Done(), it drains any remaining buffered messages before returning.
 func (lf *LiveFlow) senderLoop(
 	ctx context.Context,
+	invCtx agent.InvocationContext,
 	conn model.LiveConnection,
 	queue *agent.LiveRequestQueue,
 	eventCh chan<- eventOrError,
 ) {
+	fanOut := func(req *model.LiveRequest) {
+		for _, st := range invCtx.ActiveStreamingTools() {
+			// Best-effort: skip if the tool's queue is closed or full.
+			_ = st.Stream.Send(ctx, req)
+		}
+	}
+
 	for {
 		select {
 		case req := <-queue.Events():
@@ -193,6 +202,7 @@ func (lf *LiveFlow) senderLoop(
 				sendEvent(ctx, eventCh, eventOrError{err: err})
 				return
 			}
+			fanOut(req)
 		case <-queue.Done():
 			// Drain any buffered messages before exiting.
 			for {
@@ -202,11 +212,19 @@ func (lf *LiveFlow) senderLoop(
 						sendEvent(ctx, eventCh, eventOrError{err: err})
 						return
 					}
+					fanOut(req)
 				default:
+					// Close all active streaming tools on shutdown.
+					for _, st := range invCtx.ActiveStreamingTools() {
+						st.Close()
+					}
 					return
 				}
 			}
 		case <-ctx.Done():
+			for _, st := range invCtx.ActiveStreamingTools() {
+				st.Close()
+			}
 			return
 		}
 	}

--- a/internal/llminternal/base_flow_live_test.go
+++ b/internal/llminternal/base_flow_live_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llminternal
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/model"
+)
+
+func TestSenderLoop_FanOutAndCleanup(t *testing.T) {
+	t.Parallel()
+
+	toolQueue := agent.NewLiveRequestQueue(100)
+	var closed atomic.Bool
+	toolCtx, toolCancel := context.WithCancel(context.Background())
+	st := &agent.ActiveStreamingTool{
+		Name:   "test-stream",
+		Stream: toolQueue,
+		Cancel: func() {
+			closed.Store(true)
+			toolCancel()
+		},
+	}
+
+	// Create invocation context with the streaming tool registered.
+	invCtx := icontext.NewInvocationContext(context.Background(), icontext.InvocationContextParams{})
+	invCtx.AddActiveStreamingTool(st)
+
+	// Mock connection that also counts sends for fan-out verification.
+	conn := newFanOutMockConn()
+
+	// Create a queue with some messages.
+	queue := agent.NewLiveRequestQueue(10)
+	_ = queue.Send(context.Background(), &model.LiveRequest{Content: genai.NewContentFromText("hello", "user")})
+	_ = queue.Send(context.Background(), &model.LiveRequest{Content: genai.NewContentFromText("world", "user")})
+	queue.Close()
+
+	eventCh := make(chan eventOrError, 10)
+	lf := &LiveFlow{}
+
+	// Run senderLoop — it will process both messages, fan out, then
+	// the defer will close the streaming tool.
+	lf.senderLoop(context.Background(), invCtx, conn, queue, eventCh)
+
+	// Verify messages were sent to the connection.
+	if got := conn.sendCount.Load(); got != 2 {
+		t.Errorf("connection got %d sends, want 2", got)
+	}
+
+	// Verify the tool was closed on exit (defer fired).
+	if !closed.Load() {
+		t.Error("expected streaming tool to be closed after senderLoop exits")
+	}
+
+	// Ensure the tool's cancel was called.
+	select {
+	case <-toolCtx.Done():
+		// ok
+	default:
+		t.Error("expected tool context to be cancelled")
+	}
+}
+
+func TestSenderLoop_CleanupOnSendError(t *testing.T) {
+	t.Parallel()
+
+	toolQueue := agent.NewLiveRequestQueue(100)
+	var closed atomic.Bool
+	st := &agent.ActiveStreamingTool{
+		Name:   "test-stream",
+		Stream: toolQueue,
+		Cancel: func() { closed.Store(true) },
+	}
+
+	invCtx := icontext.NewInvocationContext(context.Background(), icontext.InvocationContextParams{})
+	invCtx.AddActiveStreamingTool(st)
+
+	// Connection that fails on first send.
+	conn := &fanOutMockConn{failAt: 0} //nolint:govet
+
+	queue := agent.NewLiveRequestQueue(10)
+	_ = queue.Send(context.Background(), &model.LiveRequest{Content: genai.NewContentFromText("fail", "user")})
+	queue.Close()
+
+	eventCh := make(chan eventOrError, 10)
+	lf := &LiveFlow{}
+
+	lf.senderLoop(context.Background(), invCtx, conn, queue, eventCh)
+
+	// Tool should still be closed even when conn.Send errors.
+	if !closed.Load() {
+		t.Error("expected streaming tool to be closed on send error exit")
+	}
+
+	// Should have an error in eventCh.
+	select {
+	case msg := <-eventCh:
+		if msg.err == nil {
+			t.Error("expected error event from failed send")
+		}
+	default:
+		t.Error("expected error event in eventCh")
+	}
+}
+
+type fanOutMockConn struct {
+	sendCount atomic.Int32
+	failAt    int32 // index at which Send returns an error; -1 = never fail
+}
+
+func newFanOutMockConn() *fanOutMockConn {
+	return &fanOutMockConn{failAt: -1}
+}
+
+func (c *fanOutMockConn) Send(_ context.Context, _ *model.LiveRequest) error {
+	idx := c.sendCount.Add(1) - 1
+	if c.failAt >= 0 && idx == c.failAt {
+		return fmt.Errorf("mock send error")
+	}
+	return nil
+}
+
+func (c *fanOutMockConn) Receive(_ context.Context) (*model.LLMResponse, error) {
+	return nil, nil
+}
+
+func (c *fanOutMockConn) Close() error { return nil }


### PR DESCRIPTION
> Migrated from https://github.com/dmora/adk-go/pull/26 (original creator: @dmora)
> Original review comments are preserved on the source PR.

---

Resolves #8. Added streaming tool concurrency allowing tools like real-time VAD or sentiment analysis to receive identical audio frames as the live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)