### PR TITLE
fix(live): turn cycle guard regression fixes for Live duplicate suppression

### DIFF
--- a/internal/llminternal/base_flow_live.go
+++ b/internal/llminternal/base_flow_live.go
@@ -58,6 +58,16 @@ type coalesceState struct {
 	timer          *time.Timer
 	inFlightCancel map[string]context.CancelFunc
 	flushCh        chan struct{} // signaled by timer; consumed by receiver loop
+	// nonThoughtIDs holds the set of buffered FunctionCall IDs that came
+	// from non-thought parts. Maintained in lockstep with `buffer`:
+	//   - bufferToolCalls inserts on buffer-add (skipping thought parts)
+	//   - handleToolCancellation removes when a cancelled call is dropped
+	//   - collectBufferedCalls reads len() and clears on drain
+	// flushToolCalls uses len(nonThoughtIDs) to decide whether to reset
+	// the turn-cycle guard at the FunctionResponse boundary. Tracking IDs
+	// (rather than a bool) keeps the gate accurate when a real call is
+	// cancelled before flush and only thought calls remain.
+	nonThoughtIDs map[string]struct{}
 }
 
 type recvResult struct {
@@ -85,6 +95,13 @@ func (g *turnCycleGuard) onTurnComplete() {
 	if g.contentDelivered {
 		g.suppressActive = true
 	}
+}
+
+// markContentDelivered records that model content was emitted in the current
+// turn. Used by the Interrupted bypass path so a subsequent onTurnComplete
+// arms suppression for any post-Interrupted duplicates that may follow.
+func (g *turnCycleGuard) markContentDelivered() {
+	g.contentDelivered = true
 }
 
 func (g *turnCycleGuard) reset() {
@@ -390,6 +407,7 @@ func (lf *LiveFlow) startSessionLoops(
 		dedup:          make(map[string]string),
 		inFlightCancel: make(map[string]context.CancelFunc),
 		flushCh:        make(chan struct{}, 1),
+		nonThoughtIDs:  make(map[string]struct{}),
 	}
 	turnResetCh := make(chan struct{}, 1)
 
@@ -621,7 +639,7 @@ func (lf *LiveFlow) receiverLoop(
 				return
 			}
 		case <-cs.flushCh:
-			lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh)
+			lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh, guard)
 		case <-turnResetCh:
 			guard.reset()
 		case <-ctx.Done():
@@ -690,12 +708,15 @@ func (lf *LiveFlow) processMessage(
 	}
 
 	if hasFunctionCallParts(resp) {
-		guard.reset() // model-initiated tool call = new conversational context
+		// FC-arrival no longer resets the guard; the FunctionResponse
+		// boundary owns the reset (see flushToolCalls), gated on the
+		// presence of at least one non-thought call. Thought-only
+		// emissions therefore never end the turn cycle on their own.
 		lf.bufferToolCalls(cs, resp)
 		return
 	}
 
-	lf.flushCoalesceBuffer(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh)
+	lf.flushCoalesceBuffer(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh, guard)
 
 	isAudio := false
 	if resp.CustomMetadata != nil {
@@ -738,21 +759,52 @@ func (lf *LiveFlow) processMessage(
 	sendEvent(ctx, eventCh, eventOrError{event: ev})
 }
 
-// applyTurnCycleGuard evaluates the guard for the given response.
-// Returns nil if the message should be fully suppressed.
-// Returns a (possibly modified) response otherwise.
+// applyTurnCycleGuard evaluates the guard for the given response and returns
+// the response to forward downstream, or nil when the message should be
+// fully suppressed.
+//
+// Suppression matrix (when the guard is armed and the message is model-
+// content-bearing — i.e. Content!=nil with role=="model" and !isAudio):
+//
+//	Content+OT only       → nil (fully suppressed)
+//	Content+OT+IT         → Content/OT stripped, IT preserved
+//	Content+IT (no OT)    → Content stripped, IT preserved
+//
+// OT-stripping nuance: OutputTranscription is stripped only when the
+// response is model-content-bearing AND the guard suppresses. An OT-only
+// message (Content==nil) is a documented bypass case — isModelContent is
+// false, the guard is not consulted, and OT is forwarded untouched. Audio
+// model content also bypasses the guard via the !isAudio carve-out, so
+// audio frames are never stripped here.
+//
+// InputTranscription (user input) is never stripped: it is not a model
+// duplicate. The Interrupted branch bypasses the suppress check for the
+// current message (it carries the truncated model output, which the
+// caller must observe) and arms the guard so post-Interrupted duplicates
+// that arrive before user activity are suppressed.
 func applyTurnCycleGuard(resp *model.LLMResponse, guard *turnCycleGuard, isAudio bool) *model.LLMResponse {
 	isModelContent := resp.Content != nil && resp.Content.Role == "model" && !isAudio
-	hasTranscription := resp.InputTranscription != nil || resp.OutputTranscription != nil
 
-	// Check guard INDEPENDENTLY of transcription.
+	// Interrupted: the truncated model output IS this message — deliver it
+	// (bypass suppression). Arm the guard so any subsequent duplicates that
+	// arrive before user activity are suppressed.
+	if resp.Interrupted {
+		if isModelContent {
+			guard.markContentDelivered()
+		}
+		guard.onTurnComplete()
+		return resp
+	}
+
 	suppressModelContent := false
 	if isModelContent {
 		suppressModelContent = guard.onModelContent()
 	}
 
-	// Track TurnComplete in guard regardless of suppress decision.
-	if resp.TurnComplete || resp.Interrupted {
+	// Arm only on a non-partial TurnComplete. Partial events fire before
+	// the aggregate that carries the real content; arming on them would
+	// strip the aggregate's content.
+	if resp.TurnComplete && !resp.Partial {
 		guard.onTurnComplete()
 	}
 
@@ -760,13 +812,16 @@ func applyTurnCycleGuard(resp *model.LLMResponse, guard *turnCycleGuard, isAudio
 		return resp
 	}
 
-	if !hasTranscription {
-		return nil // pure model content, fully suppressed
-	}
-
-	// Mixed message: strip model content, keep transcription.
+	// Suppression: strip model output (Content + OutputTranscription).
+	// InputTranscription (user input) is preserved since it is not a
+	// model duplicate. With no IT remaining, the message is fully
+	// suppressed (return nil).
 	stripped := *resp
 	stripped.Content = nil
+	stripped.OutputTranscription = nil
+	if stripped.InputTranscription == nil {
+		return nil
+	}
 	return &stripped
 }
 
@@ -819,6 +874,9 @@ func (lf *LiveFlow) bufferToolCalls(
 			continue
 		}
 		fc := part.FunctionCall
+		if !part.Thought {
+			cs.nonThoughtIDs[fc.ID] = struct{}{}
+		}
 		hash := hashCall(fc.Name, fc.Args)
 		if _, ok := cs.dedup[hash]; !ok {
 			cs.dedup[hash] = fc.ID
@@ -859,6 +917,7 @@ func (lf *LiveFlow) flushCoalesceBuffer(
 	ts *liveTimingState,
 	queue *agent.LiveRequestQueue,
 	eventCh chan<- eventOrError,
+	guard *turnCycleGuard,
 ) {
 	cs.mu.Lock()
 	if cs.timer != nil {
@@ -876,7 +935,7 @@ func (lf *LiveFlow) flushCoalesceBuffer(
 	if empty {
 		return
 	}
-	lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh)
+	lf.flushToolCalls(ctx, invCtx, conn, cs, toolsFuncMap, ts, queue, eventCh, guard)
 }
 
 func (lf *LiveFlow) flushToolCalls(
@@ -888,8 +947,9 @@ func (lf *LiveFlow) flushToolCalls(
 	ts *liveTimingState,
 	queue *agent.LiveRequestQueue,
 	eventCh chan<- eventOrError,
+	guard *turnCycleGuard,
 ) {
-	calls := lf.collectBufferedCalls(cs)
+	calls, hasNonThought := lf.collectBufferedCalls(cs)
 	if len(calls) == 0 {
 		return
 	}
@@ -911,9 +971,27 @@ func (lf *LiveFlow) flushToolCalls(
 		return
 	}
 	lf.emitFunctionResponseEvent(ctx, invCtx, responses, queue, ts, toolExecTime, eventCh)
+
+	// Reset the turn-cycle guard only after the FunctionResponse was
+	// successfully emitted, and only if the batch contained at least one
+	// non-thought call. Thought-only batches must preserve guard state so
+	// post-thought duplicates remain suppressed. A failed trackedSend
+	// returns above without resetting — the cycle didn't close, so the
+	// guard must stay armed.
+	if hasNonThought {
+		guard.reset()
+	}
 }
 
-func (lf *LiveFlow) collectBufferedCalls(cs *coalesceState) map[string]*genai.FunctionCall {
+// collectBufferedCalls drains the buffered FunctionCalls together with a
+// snapshot of whether any non-thought call was present in the batch.
+// Returning the flag alongside the calls keeps the drain atomic — the
+// post-flushToolCalls reset gating in flushToolCalls observes the same
+// batch boundary as the buffer it just emptied. Cancellations between
+// buffer-add and drain are already reflected in nonThoughtIDs (see
+// handleToolCancellation), so a real call cancelled before flush does
+// not falsely arm the reset.
+func (lf *LiveFlow) collectBufferedCalls(cs *coalesceState) (map[string]*genai.FunctionCall, bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
@@ -922,14 +1000,20 @@ func (lf *LiveFlow) collectBufferedCalls(cs *coalesceState) map[string]*genai.Fu
 		cs.timer = nil
 	}
 	if len(cs.buffer) == 0 {
-		return nil
+		// Clear the set even on empty drains so a stale entry can't
+		// bleed into the next batch (defence in depth — handlers
+		// already keep the set in sync with the buffer).
+		cs.nonThoughtIDs = make(map[string]struct{})
+		return nil, false
 	}
 
 	calls := make(map[string]*genai.FunctionCall, len(cs.buffer))
 	maps.Copy(calls, cs.buffer)
 	cs.buffer = make(map[string]*genai.FunctionCall)
 	cs.dedup = make(map[string]string)
-	return calls
+	hasNonThought := len(cs.nonThoughtIDs) > 0
+	cs.nonThoughtIDs = make(map[string]struct{})
+	return calls, hasNonThought
 }
 
 type callGroup struct {
@@ -1144,6 +1228,10 @@ func handleToolCancellation(cs *coalesceState, cancelledIDs []string) {
 	defer cs.mu.Unlock()
 	for _, id := range cancelledIDs {
 		delete(cs.buffer, id)
+		// Keep the non-thought set in sync with the buffer. If a real
+		// (non-thought) call is cancelled before flush, the post-flush
+		// reset must NOT fire when only thought calls remain.
+		delete(cs.nonThoughtIDs, id)
 		if cancelFn, ok := cs.inFlightCancel[id]; ok {
 			cancelFn()
 			delete(cs.inFlightCancel, id)

--- a/internal/llminternal/turn_cycle_guard_test.go
+++ b/internal/llminternal/turn_cycle_guard_test.go
@@ -14,7 +14,13 @@
 
 package llminternal
 
-import "testing"
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+)
 
 func TestTurnCycleGuard(t *testing.T) {
 	tests := []struct {
@@ -95,12 +101,209 @@ func TestTurnCycleGuard(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "markContentDelivered then onTurnComplete arms",
+			run: func(t *testing.T, g *turnCycleGuard) {
+				g.markContentDelivered()
+				g.onTurnComplete()
+				if !g.onModelContent() {
+					t.Error("expected suppression after markContentDelivered + onTurnComplete")
+				}
+			},
+		},
+		{
+			name: "markContentDelivered alone does not arm",
+			run: func(t *testing.T, g *turnCycleGuard) {
+				g.markContentDelivered()
+				if g.onModelContent() {
+					t.Error("markContentDelivered without onTurnComplete should not arm")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &turnCycleGuard{}
 			tt.run(t, g)
+		})
+	}
+}
+
+// modelTextResp is a helper for applyTurnCycleGuard tests that returns a
+// model-role text response.
+func modelTextResp(text string) *model.LLMResponse {
+	return &model.LLMResponse{Content: genai.NewContentFromText(text, "model")}
+}
+
+func TestApplyTurnCycleGuard_Interrupted(t *testing.T) {
+	t.Run("Interrupted bypasses suppression and arms", func(t *testing.T) {
+		g := &turnCycleGuard{}
+		// Arm the guard via a normal turn.
+		_ = applyTurnCycleGuard(&model.LLMResponse{
+			Content:      genai.NewContentFromText("A", "model"),
+			TurnComplete: true,
+		}, g, false)
+
+		// Interrupted message must be delivered (not suppressed) even
+		// while the guard is armed.
+		out := applyTurnCycleGuard(&model.LLMResponse{
+			Content:     genai.NewContentFromText("B", "model"),
+			Interrupted: true,
+		}, g, false)
+		if out == nil {
+			t.Fatal("Interrupted message must not be suppressed")
+		}
+		if out.Content == nil || out.Content.Parts[0].Text != "B" {
+			t.Errorf("expected Interrupted content B, got %+v", out.Content)
+		}
+
+		// A duplicate that follows must be suppressed: Interrupted armed.
+		dup := applyTurnCycleGuard(modelTextResp("B"), g, false)
+		if dup != nil {
+			t.Error("duplicate after Interrupted must be suppressed (Interrupted should arm)")
+		}
+	})
+}
+
+func TestApplyTurnCycleGuard_PartialDoesNotArm(t *testing.T) {
+	g := &turnCycleGuard{}
+	// Partial+TurnComplete with content should NOT arm the guard.
+	_ = applyTurnCycleGuard(&model.LLMResponse{
+		Content:      genai.NewContentFromText("A", "model"),
+		Partial:      true,
+		TurnComplete: true,
+	}, g, false)
+
+	// Subsequent model content with no Partial must NOT be suppressed.
+	out := applyTurnCycleGuard(modelTextResp("A"), g, false)
+	if out == nil {
+		t.Error("partial TurnComplete should not arm guard; subsequent content was incorrectly suppressed")
+	}
+}
+
+func TestApplyTurnCycleGuard_StripPathMatrix(t *testing.T) {
+	cases := []struct {
+		name           string
+		resp           *model.LLMResponse
+		isAudio        bool
+		armBeforeCall  bool
+		wantNil        bool
+		wantContent    bool
+		wantOT         bool
+		wantIT         bool
+		wantUnchanged  bool // if true, returned response must equal input pointer-wise
+		descriptionKey string
+	}{
+		{
+			name: "model content only — fully suppressed",
+			resp: &model.LLMResponse{
+				Content: genai.NewContentFromText("dup", "model"),
+			},
+			armBeforeCall: true,
+			wantNil:       true,
+		},
+		{
+			name: "model content + OT (no IT) — fully suppressed",
+			resp: &model.LLMResponse{
+				Content:             genai.NewContentFromText("dup", "model"),
+				OutputTranscription: &genai.Transcription{Text: "dup", Finished: true},
+			},
+			armBeforeCall: true,
+			wantNil:       true,
+		},
+		{
+			name: "model content + IT — Content stripped, IT preserved",
+			resp: &model.LLMResponse{
+				Content:            genai.NewContentFromText("dup", "model"),
+				InputTranscription: &genai.Transcription{Text: "user said hi", Finished: true},
+			},
+			armBeforeCall: true,
+			wantContent:   false,
+			wantOT:        false,
+			wantIT:        true,
+		},
+		{
+			name: "model content + OT + IT — Content+OT stripped, IT preserved",
+			resp: &model.LLMResponse{
+				Content:             genai.NewContentFromText("dup", "model"),
+				OutputTranscription: &genai.Transcription{Text: "dup", Finished: true},
+				InputTranscription:  &genai.Transcription{Text: "user said hi", Finished: true},
+			},
+			armBeforeCall: true,
+			wantContent:   false,
+			wantOT:        false,
+			wantIT:        true,
+		},
+		{
+			name: "OT-only (no Content) — bypass: response unchanged",
+			resp: &model.LLMResponse{
+				OutputTranscription: &genai.Transcription{Text: "out", Finished: true},
+			},
+			armBeforeCall: true,
+			wantUnchanged: true,
+		},
+		{
+			name: "IT-only (no Content) — bypass: response unchanged",
+			resp: &model.LLMResponse{
+				InputTranscription: &genai.Transcription{Text: "in", Finished: true},
+			},
+			armBeforeCall: true,
+			wantUnchanged: true,
+		},
+		{
+			name: "audio model content — bypass via isAudio carve-out",
+			resp: &model.LLMResponse{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{InlineData: &genai.Blob{MIMEType: "audio/pcm", Data: []byte{0x01}}},
+					},
+				},
+			},
+			isAudio:       true,
+			armBeforeCall: true,
+			wantUnchanged: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &turnCycleGuard{}
+			if tc.armBeforeCall {
+				// Arm the guard with a prior turn so suppression is active.
+				_ = applyTurnCycleGuard(&model.LLMResponse{
+					Content:      genai.NewContentFromText("prior", "model"),
+					TurnComplete: true,
+				}, g, false)
+			}
+
+			out := applyTurnCycleGuard(tc.resp, g, tc.isAudio)
+
+			if tc.wantNil {
+				if out != nil {
+					t.Errorf("expected nil (fully suppressed), got %+v", out)
+				}
+				return
+			}
+			if tc.wantUnchanged {
+				if out != tc.resp {
+					t.Errorf("expected unchanged response (same pointer), got different value")
+				}
+				return
+			}
+			if out == nil {
+				t.Fatal("unexpected nil result")
+			}
+			if tc.wantContent != (out.Content != nil) {
+				t.Errorf("Content presence: got %v, want %v", out.Content != nil, tc.wantContent)
+			}
+			if tc.wantOT != (out.OutputTranscription != nil) {
+				t.Errorf("OutputTranscription presence: got %v, want %v", out.OutputTranscription != nil, tc.wantOT)
+			}
+			if tc.wantIT != (out.InputTranscription != nil) {
+				t.Errorf("InputTranscription presence: got %v, want %v", out.InputTranscription != nil, tc.wantIT)
+			}
 		})
 	}
 }

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -397,6 +397,32 @@ func mixedResponse(text, transcriptionText string) *model.LLMResponse {
 	}
 }
 
+// thoughtFunctionCallResponse creates a model response containing a
+// thought-only FunctionCall part (Thought=true). Used to verify the guard
+// is preserved across model "thinking" emissions.
+func thoughtFunctionCallResponse(id, name string, args map[string]any) *model.LLMResponse {
+	return &model.LLMResponse{
+		Content: &genai.Content{
+			Role: "model",
+			Parts: []*genai.Part{{
+				Thought:      true,
+				FunctionCall: &genai.FunctionCall{ID: id, Name: name, Args: args},
+			}},
+		},
+	}
+}
+
+// partialTurnCompleteResponse creates a Partial=true + TurnComplete=true
+// model response carrying text. Mirrors the streaming aggregator's partial
+// emission that precedes the aggregate.
+func partialTurnCompleteResponse(text string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Content:      genai.NewContentFromText(text, "model"),
+		Partial:      true,
+		TurnComplete: true,
+	}
+}
+
 // modelContentTexts extracts text from model-content events.
 func modelContentTexts(events []*session.Event) []string {
 	var texts []string
@@ -1168,20 +1194,41 @@ func persistedTexts(events []*session.Event) []string {
 // ---------------------------------------------------------------------------
 
 func TestScenario14_TurnCompleteBoundaryFlush(t *testing.T) {
+	// Two distinct speaking segments separated by a real turn boundary.
+	// User activity between segments resets the turn-cycle guard via
+	// turnResetCh; without that reset, fix #5 would treat segment two as
+	// a post-TurnComplete duplicate and strip its model output (Content
+	// AND OutputTranscription), preventing the OT aggregator from
+	// flushing the second persisted transcript.
 	conn := newMockLiveConnection()
-	conn.recvResponses = []*model.LLMResponse{
-		// First speaking segment: two output chunks, then TurnComplete.
-		transcriptResponse("Hello, ", "output", false),
-		transcriptResponse("how are you?", "output", false),
-		turnCompleteResponse(),
-		// Second speaking segment: one chunk, then TurnComplete.
-		transcriptResponse("I found the patient.", "output", false),
-		turnCompleteResponse(),
-	}
+	conn.recvCh = make(chan *model.LLMResponse, 10)
 
 	r, svc, _ := setupRunner(t, conn, nil, nil)
 	queue := agent.NewLiveRequestQueue(100)
-	queue.Close()
+
+	go func() {
+		// First speaking segment: two output chunks, then TurnComplete.
+		conn.recvCh <- transcriptResponse("Hello, ", "output", false)
+		conn.recvCh <- transcriptResponse("how are you?", "output", false)
+		conn.recvCh <- turnCompleteResponse()
+
+		// Allow receiverLoop to process the segment + arm the guard.
+		time.Sleep(50 * time.Millisecond)
+
+		// User activity — senderLoop signals turnResetCh, resetting the
+		// guard so the next speaking segment is not suppressed.
+		_ = queue.Send(context.Background(), &model.LiveRequest{
+			Content: genai.NewContentFromText("ack", "user"),
+		})
+		time.Sleep(50 * time.Millisecond)
+
+		// Second speaking segment: one chunk, then TurnComplete.
+		conn.recvCh <- transcriptResponse("I found the patient.", "output", false)
+		conn.recvCh <- turnCompleteResponse()
+
+		time.Sleep(50 * time.Millisecond)
+		queue.Close()
+	}()
 
 	events, errs := collectEvents(t, r, queue)
 	if len(errs) > 0 {
@@ -1642,10 +1689,15 @@ func TestScenario22_SuppressedTurnCompleteDrivesSetModelSpeaking(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 23: Mixed transcription+content — content suppressed, transcription emitted
+// Scenario 23: Mixed message during armed guard — fully suppressed
 // ---------------------------------------------------------------------------
 
-func TestScenario23_MixedMessageContentSuppressedTranscriptionEmitted(t *testing.T) {
+func TestScenario23_MixedMessageFullySuppressedDuringArmedGuard(t *testing.T) {
+	// Under fix #5, a mixed model-content + OutputTranscription message
+	// during armed state has BOTH Content and OutputTranscription stripped.
+	// With no InputTranscription remaining, the message is fully
+	// suppressed (no event emitted at all) — preserving previous behavior
+	// for the model-content side and adding OT-strip parity.
 	conn := newMockLiveConnection()
 	conn.recvResponses = []*model.LLMResponse{
 		textResponse("A"),
@@ -1662,34 +1714,37 @@ func TestScenario23_MixedMessageContentSuppressedTranscriptionEmitted(t *testing
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 
+	if len(events) != 2 {
+		t.Fatalf("expected 2 yielded events (mixed message fully suppressed), got %d", len(events))
+	}
+
 	// Model content "A" should appear only once.
 	texts := modelContentTexts(events)
 	if len(texts) != 1 || texts[0] != "A" {
 		t.Errorf("expected [A], got %v", texts)
 	}
 
-	// The mixed message event should have Content==nil but transcription intact.
-	lastEv := events[len(events)-1]
-	if lastEv.Content != nil {
-		t.Error("mixed message event should have Content stripped (nil)")
-	}
-	if lastEv.OutputTranscription == nil || lastEv.OutputTranscription.Text != "hello" {
-		t.Error("mixed message event should preserve output transcription")
+	// Defence in depth: no event must carry the duplicate OT.
+	for i, ev := range events {
+		if ev.OutputTranscription != nil && ev.OutputTranscription.Text == "hello" {
+			t.Errorf("event[%d] leaked OutputTranscription %q (must be stripped on suppress)", i, ev.OutputTranscription.Text)
+		}
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 24: Post-Interrupted known limitation — out of scope for #34
+// Scenario 24: Interrupted bypasses suppression and arms the guard
 // ---------------------------------------------------------------------------
 
-func TestScenario24_PostInterruptedKnownLimitation(t *testing.T) {
-	// Documents known false positive — out of scope for issue #34.
-	// If the model is Interrupted and immediately sends new content
-	// before turnResetCh fires, the guard may suppress it.
+func TestScenario24_InterruptedBypassesSuppressionAndArms(t *testing.T) {
+	// Under fix #1, an Interrupted message bypasses the guard's suppress
+	// check (the truncated model output IS this message — it must be
+	// observed) AND arms the guard so any post-Interrupted duplicates
+	// that arrive before user activity are suppressed.
 	conn := newMockLiveConnection()
 	conn.recvResponses = []*model.LLMResponse{
-		textResponseWithTurnComplete("A"),
-		textResponseInterrupted("B"),
+		textResponseWithTurnComplete("A"), // arms guard
+		textResponseInterrupted("B"),      // bypasses suppression
 	}
 
 	r, _, _ := setupRunner(t, conn, nil, nil)
@@ -1698,10 +1753,10 @@ func TestScenario24_PostInterruptedKnownLimitation(t *testing.T) {
 
 	events, _ := collectEvents(t, r, queue)
 
-	// "A" is emitted. "B" is suppressed (known false positive).
+	// Both A and B emitted: Interrupted message bypasses the armed guard.
 	texts := modelContentTexts(events)
-	if len(texts) != 1 || texts[0] != "A" {
-		t.Errorf("expected only [A] emitted (B suppressed as known limitation), got %v", texts)
+	if len(texts) != 2 || texts[0] != "A" || texts[1] != "B" {
+		t.Errorf("expected [A B] (Interrupted bypasses suppression), got %v", texts)
 	}
 
 	// SetModelSpeaking(false) must still fire for Interrupted.
@@ -2057,6 +2112,320 @@ func TestScenario30_InputFlushedBeforeTextContent(t *testing.T) {
 	}
 	if persisted[1].Author == "user" {
 		t.Error("second persisted event should not have Author=user")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Partial TurnComplete does not arm suppression
+// ---------------------------------------------------------------------------
+
+func TestScenario_PartialTurnCompleteDoesNotArm(t *testing.T) {
+	// Under fix #3, the guard arms only on a non-partial TurnComplete.
+	// Partial TurnComplete events fire before the aggregate that carries
+	// the real content; arming on them would strip the aggregate's content.
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		partialTurnCompleteResponse("A"), // partial — must not arm
+		textResponse("A"),                // would be a duplicate IF armed
+		turnCompleteResponse(),
+	}
+
+	r, _, _ := setupRunner(t, conn, nil, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	texts := modelContentTexts(events)
+	// Both partial and aggregate emit "A"; the second is NOT suppressed
+	// because partial TurnComplete didn't arm the guard.
+	if len(texts) != 2 {
+		t.Errorf("expected 2 model-content events (partial did not arm), got %v", texts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Thought-only FunctionCall does not reset the guard
+// ---------------------------------------------------------------------------
+
+func TestScenario_ThoughtOnlyFunctionCallDoesNotResetGuard(t *testing.T) {
+	// Under fix #4 the FC-arrival path no longer resets the guard, and
+	// under fix #2 the FunctionResponse boundary reset is gated on the
+	// presence of at least one non-thought call. So a thought-only batch
+	// preserves the armed guard, and the duplicate that follows remains
+	// suppressed.
+	thoughtTool := &mockTool{name: "thought", result: map[string]any{}}
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		textResponse("Hello"),
+		turnCompleteResponse(), // arms guard
+		thoughtFunctionCallResponse("fc1", "thought", nil),
+		textResponse("Hello"), // duplicate — must remain suppressed
+		turnCompleteResponse(),
+	}
+
+	r, _, _ := setupRunner(t, conn, []tool.Tool{thoughtTool}, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	texts := modelContentTexts(events)
+	if len(texts) != 1 || texts[0] != "Hello" {
+		t.Errorf("expected [Hello] (duplicate suppressed across thought call), got %v", texts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: OutputTranscription is stripped when the guard suppresses
+// ---------------------------------------------------------------------------
+
+func TestScenario_OutputTranscriptionStrippedOnSuppress(t *testing.T) {
+	// transcriptResponse(text, "output", true) sets BOTH Content
+	// (role=model, text=text) AND OutputTranscription{Text:text,
+	// Finished:true} — that is the Gemini Live invariant the suppress
+	// path is meant to handle. Under fix #5, suppression strips Content
+	// and OT both; with no InputTranscription the message is fully
+	// suppressed (no event emitted at all).
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		textResponse("Greeting"),
+		turnCompleteResponse(), // arms guard
+		transcriptResponse("Greeting", "output", true),
+	}
+
+	r, _, _ := setupRunner(t, conn, nil, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (third fully suppressed), got %d", len(events))
+	}
+
+	// Defence in depth: even if a future change kept the event in the
+	// stream, OT must not leak through.
+	for i, ev := range events {
+		if ev.OutputTranscription != nil && ev.OutputTranscription.Text == "Greeting" {
+			t.Errorf("event[%d] leaked OutputTranscription %q (must be stripped on suppress)", i, ev.OutputTranscription.Text)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Mixed-content suppress preserves InputTranscription
+// ---------------------------------------------------------------------------
+
+func TestScenario_SuppressedMixedContentPreservesInputTranscription(t *testing.T) {
+	// Validates the IT-preserved branch of the strip matrix: when a
+	// suppressed message carries an InputTranscription alongside model
+	// Content + OutputTranscription, only the model output is stripped.
+	// IT survives because it represents user input, not a model duplicate.
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		textResponse("Hello"),
+		turnCompleteResponse(), // arms guard
+		{
+			Content:             genai.NewContentFromText("Hello", "model"),
+			OutputTranscription: &genai.Transcription{Text: "Hello", Finished: true},
+			InputTranscription:  &genai.Transcription{Text: "User said hi", Finished: true},
+		},
+	}
+
+	r, _, _ := setupRunner(t, conn, nil, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	last := events[len(events)-1]
+	if last.Content != nil {
+		t.Error("Content must be stripped on suppress")
+	}
+	if last.OutputTranscription != nil {
+		t.Error("OutputTranscription must be stripped on suppress")
+	}
+	if last.InputTranscription == nil || last.InputTranscription.Text != "User said hi" {
+		t.Errorf("InputTranscription must be preserved; got %+v", last.InputTranscription)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: FunctionResponse boundary resets the guard (fix #2)
+// ---------------------------------------------------------------------------
+
+// This is the negative-control for fix #2. With fix #4 removing the
+// FC-arrival reset, the only thing that lets the second "A" through is
+// the post-flushToolCalls reset. Removing that reset breaks this test.
+func TestScenario_FunctionResponseBoundaryResets(t *testing.T) {
+	greet := &mockTool{name: "greet", result: map[string]any{"msg": "hi"}}
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		textResponse("A"),
+		turnCompleteResponse(), // arms guard
+		functionCallResponse("fc1", "greet", nil),
+		// Under fix #4 the FC-arrival path no longer resets the guard,
+		// so this duplicate would still be suppressed if fix #2 is
+		// missing.
+		textResponse("A"),
+		turnCompleteResponse(),
+	}
+
+	r, _, _ := setupRunner(t, conn, []tool.Tool{greet}, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	texts := modelContentTexts(events)
+	// Both "A" emitted: the second comes after the FunctionResponse
+	// boundary reset (fix #2). Without that reset the guard stays armed
+	// across the FC cycle and the second A is suppressed.
+	if len(texts) != 2 || texts[0] != "A" || texts[1] != "A" {
+		t.Errorf("expected [A A] (FR boundary reset enabled second A), got %v", texts)
+	}
+	if greet.CallCount() != 1 {
+		t.Errorf("expected greet called once, got %d", greet.CallCount())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Non-thought cancelled before flush — thought-only batch must not reset guard
+// ---------------------------------------------------------------------------
+
+// Negative control: if a non-thought FunctionCall is buffered and then
+// cancelled before the coalesce timer fires, only the thought call
+// remains at flush time. The post-flushToolCalls reset must NOT fire
+// (cycle did not actually cross a real-FR boundary), and a duplicate
+// model emission that arrives after the thought-only flush must remain
+// suppressed by the still-armed guard.
+//
+// Without the cancellation hook into nonThoughtIDs, this test fails:
+// the stale "had a non-thought call" flag drives an incorrect reset and
+// the duplicate "Hello" leaks through.
+func TestScenario_NonThoughtCancelledThoughtOnlyDoesNotReset(t *testing.T) {
+	realTool := &mockTool{name: "real_tool", result: map[string]any{"ok": true}}
+	thoughtTool := &mockTool{name: "thought", result: map[string]any{}}
+
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 20)
+
+	llm := &mockLiveLLM{conn: conn}
+	a, _ := llmagent.New(llmagent.Config{
+		Name:  "test_agent",
+		Model: llm,
+		Tools: []tool.Tool{realTool, thoughtTool},
+	})
+
+	svc := &mockSessionService{Service: session.InMemoryService()}
+	_, _ = svc.Service.Create(context.Background(), &session.CreateRequest{
+		AppName: "test", UserID: "user1", SessionID: "sess1",
+	})
+
+	r, _ := New(Config{
+		AppName:        "test",
+		Agent:          a,
+		SessionService: svc,
+	})
+
+	queue := agent.NewLiveRequestQueue(100)
+
+	go func() {
+		// Arm the guard on a genuine turn.
+		conn.recvCh <- textResponse("Hello")
+		conn.recvCh <- turnCompleteResponse()
+		// Allow receiverLoop to process the arming pair before the FC
+		// burst lands — keeps the suppression-active state observable
+		// when the duplicate "Hello" arrives later.
+		time.Sleep(50 * time.Millisecond)
+
+		// Buffer one non-thought FC and one thought FC together.
+		conn.recvCh <- functionCallResponse("fc_real", "real_tool", nil)
+		conn.recvCh <- thoughtFunctionCallResponse("fc_thought", "thought", nil)
+		// Wait for both to be buffered. Coalesce window is 500ms below,
+		// so the timer has not fired yet.
+		time.Sleep(50 * time.Millisecond)
+
+		// Cancel ONLY the non-thought call — must arrive before flush.
+		conn.recvCh <- toolCancellationResponse([]string{"fc_real"})
+		// Wait for: cancellation processing, coalesce window expiry,
+		// thought-tool execution, FunctionResponse send.
+		time.Sleep(700 * time.Millisecond)
+
+		// Duplicate model emission — must be suppressed by the still-
+		// armed guard if the thought-only flush did NOT reset it.
+		conn.recvCh <- textResponse("Hello")
+		conn.recvCh <- turnCompleteResponse()
+
+		time.Sleep(50 * time.Millisecond)
+		queue.Close()
+	}()
+
+	cfg := agent.RunConfig{ToolCoalesceWindow: 500 * time.Millisecond}
+	var events []*session.Event
+	for ev, err := range r.RunLive(context.Background(), "user1", "sess1", queue, cfg) {
+		if err != nil {
+			break
+		}
+		if ev != nil {
+			events = append(events, ev)
+		}
+	}
+
+	texts := modelContentTexts(events)
+	if len(texts) != 1 || texts[0] != "Hello" {
+		t.Errorf("expected only [Hello] (duplicate must remain suppressed; thought-only flush must not reset guard), got %v", texts)
+	}
+
+	// The cancelled non-thought call must NOT have been executed.
+	if realTool.CallCount() != 0 {
+		t.Errorf("expected real_tool not called (cancelled before flush), got %d", realTool.CallCount())
+	}
+	// The thought call must have been executed (still in the buffer).
+	if thoughtTool.CallCount() != 1 {
+		t.Errorf("expected thought tool called once, got %d", thoughtTool.CallCount())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Audio model content bypasses the turn-cycle guard
+// ---------------------------------------------------------------------------
+
+func TestScenario_AudioBypassesGuard(t *testing.T) {
+	// Audio model content must bypass the guard regardless of armed
+	// state — applyTurnCycleGuard's !isAudio carve-out preserves audio
+	// frames even after a TurnComplete arms suppression.
+	conn := newMockLiveConnection()
+	conn.recvResponses = []*model.LLMResponse{
+		textResponse("A"),
+		turnCompleteResponse(),      // arms guard
+		audioResponse([]byte{0x01}), // would be suppressed if !isAudio carve-out broke
+		audioResponse([]byte{0x02}),
+	}
+
+	r, _, _ := setupRunner(t, conn, nil, nil)
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close()
+
+	events, _ := collectEvents(t, r, queue)
+
+	audioCount := 0
+	for _, ev := range events {
+		if ev.Content == nil {
+			continue
+		}
+		for _, p := range ev.Content.Parts {
+			if p.InlineData != nil && p.InlineData.MIMEType == "audio/pcm" {
+				audioCount++
+			}
+		}
+	}
+	if audioCount != 2 {
+		t.Errorf("expected 2 audio events (audio bypasses guard), got %d", audioCount)
 	}
 }
 


### PR DESCRIPTION
Closes #15. Supersedes closed #33.

## Summary

Patches the existing `turnCycleGuard` (already on `main` from PR #35) with four correctness fixes derived from the parallel duplicate-suppression mechanism in `hulilabs/huli`'s `dedup` plugin (`backend/internal/apps/practice/agent/runtime/dedup/plugin.go`). Each fix has a corresponding test scenario so the upstream guard now covers the cases that consumer was guarding against locally — enabling huli to shrink its parallel implementation in a follow-up PR.

## Fixes

| # | Gap | Source |
|---|-----|--------|
| 1 | `Interrupted` bypasses suppression to deliver the truncated model output, then arms the guard so any post-interruption duplicates are caught (was: Interrupted armed without delivering, dropping the truncated message — Scenario 24's documented "known limitation") | Closed PR #33 commit `d82bc95` + refinement during review |
| 2 | `TurnComplete` only arms the guard when `!Partial`. Streaming aggregator can emit partial TurnCompletes before the aggregate carrying the real content; arming on those would strip the aggregate's Content | huli `dedup/plugin.go:132` |
| 3 | Function-response boundary resets the guard, but only if the flushed batch contained at least one non-thought tool call. Tracked via `nonThoughtIDs` map on `coalesceState`. Correctly handles cancellation of a real call between buffer and flush — without the cancellation tracking, a thought-only residual batch would incorrectly reset the guard | huli `dedup/plugin.go:317` (`isThoughtOnlyCall`) + cancellation edge case found during review |
| 4 | Suppress path strips both `Content` and `OutputTranscription` while preserving `InputTranscription` (user-side). Drops the message entirely when nothing remains | huli `dedup/plugin.go:165` |

## Why this superseded #33

PR #33 became stale (rebase debt against #36's GoAway/session-resumption work) and was bundled with PR #32's observability scaffolding (~1300 unrelated lines). This branch is decoupled from #32 and rebased on current `main` — guard fix only.

## Test plan

- [x] `go test -race -count=1 ./internal/llminternal/... ./runner/...` passes
- [x] `golangci-lint run ./internal/llminternal/... ./runner/...` clean (0 issues)
- [x] 7 new runner scenarios: `TestScenario_PartialTurnCompleteDoesNotArm`, `TestScenario_ThoughtOnlyFunctionCallDoesNotResetGuard`, `TestScenario_OutputTranscriptionStrippedOnSuppress`, `TestScenario_SuppressedMixedContentPreservesInputTranscription`, `TestScenario_FunctionResponseBoundaryResets`, `TestScenario_NonThoughtCancelledThoughtOnlyDoesNotReset`, `TestScenario_AudioBypassesGuard`
- [x] Strip-path matrix (7 cases) in `turn_cycle_guard_test.go`
- [x] Scenarios 14, 23, 24 updated to reflect new behavior
- [ ] After merge: bump `google.golang.org/adk` pin in `hulilabs/huli` and shrink the `dedup` plugin to keep only tool-result caching + MALFORMED_FUNCTION_CALL recovery (separate PR)

## Notes for reviewers

- No SDK bump. Stays on current `google.golang.org/genai` pin.
- No public API changes. `runner.RunLive` callers see only the corrected behavior.
- `LiveDiagnostics` and other observability fields are intentionally untouched — that's PR #32's scope.
- Structurally close to what would land upstream in `google/adk-go#540`. The fix treats huli's `dedup` plugin as a behavioral spec only, not as a source of huli-specific abstractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)