### PR TITLE
fix(liveflow): make history replay TurnComplete role-conditional (#48)

### DIFF
--- a/internal/llminternal/liveflow/flow.go
+++ b/internal/llminternal/liveflow/flow.go
@@ -288,45 +288,6 @@ func (lf *LiveFlow) startSessionLoops(
 	return eventCh, wg
 }
 
-func (lf *LiveFlow) sendHistory(
-	cancelCtx context.Context,
-	ctx agent.InvocationContext,
-	conn model.LiveConnection,
-	ts *liveTimingState,
-) error {
-	events := ctx.Session().Events()
-
-	// Collect non-nil content events.
-	var turns []*genai.Content
-	for i := range events.Len() {
-		ev := events.At(i)
-		if ev.Content != nil {
-			turns = append(turns, ev.Content)
-		}
-	}
-	if len(turns) == 0 {
-		return nil
-	}
-
-	// Send all history turns with TurnComplete=false so the model absorbs
-	// them as context without responding to each one individually.
-	// Only the last turn is sent with TurnComplete=true to signal
-	// that history replay is complete.
-	falseVal := false
-	for i, content := range turns {
-		isLast := i == len(turns)-1
-		req := &model.LiveRequest{Content: content}
-		if !isLast {
-			req.TurnComplete = &falseVal
-		}
-		// Last turn uses default (TurnComplete=nil → true).
-		if err := trackedSend(cancelCtx, conn, req, ts); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // ErrIter returns an iterator that yields a single error.
 func ErrIter(err error) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {

--- a/internal/llminternal/liveflow/history.go
+++ b/internal/llminternal/liveflow/history.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package liveflow
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
+)
+
+// sendHistory replays the session's stored conversation to a freshly
+// connected live session as a single batched client-content message,
+// mirroring upstream adk-go SendHistory and adk-python send_history.
+//
+// Live API semantics: turnComplete=true means "start generating with the
+// accumulated prompt", not "replay complete". A response is invited only
+// when the history ends with an unanswered user turn; a model-final history
+// (the normal case for a persisted voice thread) is absorbed silently.
+func (lf *LiveFlow) sendHistory(
+	cancelCtx context.Context,
+	ctx agent.InvocationContext,
+	conn model.LiveConnection,
+	ts *liveTimingState,
+) error {
+	events := ctx.Session().Events()
+
+	var turns []*genai.Content
+	for i := range events.Len() {
+		if c := filterAudioParts(events.At(i).Content); c != nil {
+			turns = append(turns, c)
+		}
+	}
+	if len(turns) == 0 {
+		return nil
+	}
+
+	turnComplete := turns[len(turns)-1].Role == genai.RoleUser
+	return trackedSend(cancelCtx, conn, &model.LiveRequest{
+		Contents:     turns,
+		TurnComplete: &turnComplete,
+	}, ts)
+}
+
+// filterAudioParts returns a copy of content with audio parts removed — the
+// Live API rejects audio delivered via client content (it can corrupt the
+// session), and transcripts already carry the text. Returns nil when content
+// is nil or no parts survive, so callers drop the turn entirely.
+//
+// Never mutates the input: session events share Content pointers with the
+// persisted history, so filtering must not write through them.
+func filterAudioParts(content *genai.Content) *genai.Content {
+	if content == nil {
+		return nil
+	}
+	parts := make([]*genai.Part, 0, len(content.Parts))
+	for _, part := range content.Parts {
+		if part == nil || isAudioPart(part) {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return &genai.Content{Role: content.Role, Parts: parts}
+}
+
+// isAudioPart reports whether part carries audio as inline or file data.
+func isAudioPart(part *genai.Part) bool {
+	if part.InlineData != nil && strings.HasPrefix(part.InlineData.MIMEType, "audio/") {
+		return true
+	}
+	if part.FileData != nil && strings.HasPrefix(part.FileData.MIMEType, "audio/") {
+		return true
+	}
+	return false
+}

--- a/internal/llminternal/liveflow/history_test.go
+++ b/internal/llminternal/liveflow/history_test.go
@@ -1,0 +1,318 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package liveflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/agent"
+	icontext "google.golang.org/adk/internal/context"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+)
+
+// historyInvCtx builds an InvocationContext over an in-memory session
+// seeded with the given event contents (nil entries append an event with
+// nil Content, exercising the skip path).
+func historyInvCtx(t *testing.T, contents []*genai.Content) agent.InvocationContext {
+	t.Helper()
+	parent := context.Background()
+	svc := session.InMemoryService()
+	resp, err := svc.Create(parent, &session.CreateRequest{
+		AppName: "test-app", UserID: "user-1", SessionID: "sess-1",
+	})
+	if err != nil {
+		t.Fatalf("session create: %v", err)
+	}
+	for _, c := range contents {
+		ev := session.NewEvent("inv-1")
+		ev.Content = c
+		if err := svc.AppendEvent(parent, resp.Session, ev); err != nil {
+			t.Fatalf("append event: %v", err)
+		}
+	}
+	got, err := svc.Get(parent, &session.GetRequest{
+		AppName: "test-app", UserID: "user-1", SessionID: "sess-1",
+	})
+	if err != nil {
+		t.Fatalf("session get: %v", err)
+	}
+	return icontext.NewInvocationContext(parent, icontext.InvocationContextParams{
+		Session: got.Session,
+	})
+}
+
+// sendHistoryTo runs sendHistory against conn and returns its error.
+func sendHistoryTo(t *testing.T, conn model.LiveConnection, contents []*genai.Content) error {
+	t.Helper()
+	lf := &LiveFlow{}
+	invCtx := historyInvCtx(t, contents)
+	return lf.sendHistory(context.Background(), invCtx, conn, &liveTimingState{})
+}
+
+func audioInlinePart() *genai.Part {
+	return &genai.Part{InlineData: &genai.Blob{MIMEType: "audio/pcm", Data: []byte{1, 2, 3}}}
+}
+
+func audioFilePart() *genai.Part {
+	return &genai.Part{FileData: &genai.FileData{MIMEType: "audio/wav", FileURI: "gs://b/a.wav"}}
+}
+
+func textsOf(t *testing.T, turns []*genai.Content) []string {
+	t.Helper()
+	var out []string
+	for _, turn := range turns {
+		if len(turn.Parts) == 0 {
+			t.Fatalf("turn with no parts in send: %+v", turn)
+		}
+		out = append(out, turn.Parts[0].Text)
+	}
+	return out
+}
+
+// requireSingleBatch asserts conn saw exactly one send carrying a Contents
+// batch with an explicit TurnComplete, and returns it.
+func requireSingleBatch(t *testing.T, conn *mockLiveConnTel) *model.LiveRequest {
+	t.Helper()
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if len(conn.sendLog) != 1 {
+		t.Fatalf("sends = %d, want exactly 1 batched history send", len(conn.sendLog))
+	}
+	req := conn.sendLog[0]
+	if len(req.Contents) == 0 {
+		t.Fatal("history send has empty Contents batch")
+	}
+	if req.Content != nil {
+		t.Error("history send must use Contents, not Content")
+	}
+	if req.TurnComplete == nil {
+		t.Fatal("history send must set TurnComplete explicitly")
+	}
+	return req
+}
+
+func TestSendHistory_ModelFinalAbsorbedSilently(t *testing.T) {
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		genai.NewContentFromText("hello", genai.RoleUser),
+		genai.NewContentFromText("hi there", genai.RoleModel),
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if got, want := len(req.Contents), 2; got != want {
+		t.Fatalf("batch size = %d, want %d", got, want)
+	}
+	if got := textsOf(t, req.Contents); got[0] != "hello" || got[1] != "hi there" {
+		t.Errorf("turn order = %v, want [hello, hi there]", got)
+	}
+	if *req.TurnComplete {
+		t.Error("model-final history must send TurnComplete=false (no unprompted response)")
+	}
+}
+
+func TestSendHistory_UserFinalInvitesResponse(t *testing.T) {
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		genai.NewContentFromText("hello", genai.RoleUser),
+		genai.NewContentFromText("hi there", genai.RoleModel),
+		genai.NewContentFromText("what's the weather?", genai.RoleUser),
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if got, want := len(req.Contents), 3; got != want {
+		t.Fatalf("batch size = %d, want %d", got, want)
+	}
+	if !*req.TurnComplete {
+		t.Error("user-final history must send TurnComplete=true (answer the pending turn)")
+	}
+}
+
+func TestSendHistory_StripsAudioPartsKeepsText(t *testing.T) {
+	mixed := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		genai.NewPartFromText("spoken words"),
+		audioInlinePart(),
+	}}
+	conn := newMockLiveConnTel()
+	if err := sendHistoryTo(t, conn, []*genai.Content{mixed}); err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	turn := req.Contents[0]
+	if turn.Role != genai.RoleUser {
+		t.Errorf("role = %q, want user (must be preserved)", turn.Role)
+	}
+	if len(turn.Parts) != 1 || turn.Parts[0].Text != "spoken words" {
+		t.Errorf("parts = %+v, want only the text part", turn.Parts)
+	}
+}
+
+func TestSendHistory_TurnCompleteEvaluatedOnFilteredList(t *testing.T) {
+	// adk-python parity: the trailing user turn is audio-only, so after
+	// filtering the history ends on a model turn — no response invited.
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		genai.NewContentFromText("hello", genai.RoleUser),
+		genai.NewContentFromText("hi there", genai.RoleModel),
+		{Role: genai.RoleUser, Parts: []*genai.Part{audioInlinePart()}},
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if got, want := len(req.Contents), 2; got != want {
+		t.Fatalf("batch size = %d, want %d (audio-only turn dropped)", got, want)
+	}
+	if *req.TurnComplete {
+		t.Error("TurnComplete must be computed on the filtered list → false")
+	}
+}
+
+func TestSendHistory_StripsFileDataAudio(t *testing.T) {
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{
+			genai.NewPartFromText("see attachment"),
+			audioFilePart(),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if len(req.Contents[0].Parts) != 1 || req.Contents[0].Parts[0].Text != "see attachment" {
+		t.Errorf("parts = %+v, want file-data audio stripped", req.Contents[0].Parts)
+	}
+}
+
+func TestSendHistory_NoSendWhenNothingSurvives(t *testing.T) {
+	cases := map[string][]*genai.Content{
+		"empty history": {},
+		"all audio": {
+			{Role: genai.RoleUser, Parts: []*genai.Part{audioInlinePart()}},
+			{Role: genai.RoleModel, Parts: []*genai.Part{audioInlinePart()}},
+		},
+		"nil contents and empty parts": {nil, {Role: genai.RoleUser}},
+	}
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			conn := newMockLiveConnTel()
+			if err := sendHistoryTo(t, conn, contents); err != nil {
+				t.Fatalf("sendHistory: %v", err)
+			}
+			conn.mu.Lock()
+			defer conn.mu.Unlock()
+			if len(conn.sendLog) != 0 {
+				t.Errorf("sends = %d, want 0", len(conn.sendLog))
+			}
+		})
+	}
+}
+
+func TestSendHistory_SkipsNilPartsWithoutPanic(t *testing.T) {
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{nil, genai.NewPartFromText("still here")}},
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if len(req.Contents[0].Parts) != 1 || req.Contents[0].Parts[0].Text != "still here" {
+		t.Errorf("parts = %+v, want nil part skipped", req.Contents[0].Parts)
+	}
+}
+
+func TestSendHistory_ToolHistorySurvivesAndResumes(t *testing.T) {
+	// Function-call/-response parts must pass the audio filter untouched,
+	// and a history ending on an unanswered tool response (role user)
+	// invites the model to resume — upstream semantics.
+	fc := &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{
+		{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "get_weather", Args: map[string]any{"city": "SJO"}}},
+	}}
+	fr := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+		{FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "get_weather", Response: map[string]any{"temp": 24}}},
+	}}
+	conn := newMockLiveConnTel()
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		genai.NewContentFromText("weather?", genai.RoleUser),
+		fc,
+		fr,
+	})
+	if err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+	req := requireSingleBatch(t, conn)
+	if got, want := len(req.Contents), 3; got != want {
+		t.Fatalf("batch size = %d, want %d (tool turns must survive)", got, want)
+	}
+	if req.Contents[1].Parts[0].FunctionCall == nil {
+		t.Error("function call part was dropped or altered by the filter")
+	}
+	if req.Contents[2].Parts[0].FunctionResponse == nil {
+		t.Error("function response part was dropped or altered by the filter")
+	}
+	if !*req.TurnComplete {
+		t.Error("tool-response-final history must send TurnComplete=true (model resumes)")
+	}
+}
+
+func TestSendHistory_DoesNotMutatePersistedHistory(t *testing.T) {
+	// Session events share Content pointers with persisted history (the
+	// in-memory service appends shallow copies). Filtering must build fresh
+	// slices — an in-place filter would permanently strip audio from the
+	// stored session, not just the outbound payload.
+	textPart := genai.NewPartFromText("spoken words")
+	audioPart := audioInlinePart()
+	original := &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{textPart, audioPart}}
+
+	conn := newMockLiveConnTel()
+	if err := sendHistoryTo(t, conn, []*genai.Content{original}); err != nil {
+		t.Fatalf("sendHistory: %v", err)
+	}
+
+	if len(original.Parts) != 2 {
+		t.Fatalf("original parts len = %d, want 2 — filter mutated shared history", len(original.Parts))
+	}
+	if original.Parts[0] != textPart || original.Parts[1] != audioPart {
+		t.Error("original part pointers changed — filter wrote through shared history")
+	}
+	if original.Role != genai.RoleUser {
+		t.Errorf("original role = %q, want %q — filter mutated shared history", original.Role, genai.RoleUser)
+	}
+	req := requireSingleBatch(t, conn)
+	if req.Contents[0] == original {
+		t.Error("outbound content aliases the persisted event; filter must copy")
+	}
+}
+
+func TestSendHistory_PropagatesSendError(t *testing.T) {
+	wantErr := errors.New("synthetic send failure")
+	conn := &sendErrConn{sendErr: wantErr}
+	err := sendHistoryTo(t, conn, []*genai.Content{
+		genai.NewContentFromText("hello", genai.RoleUser),
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}

--- a/model/gemini/gemini_live.go
+++ b/model/gemini/gemini_live.go
@@ -54,17 +54,29 @@ func (c *geminiLiveConnection) Send(_ context.Context, req *model.LiveRequest) e
 			ActivityEnd:    req.RealtimeInput.ActivityEnd,
 			AudioStreamEnd: req.RealtimeInput.AudioStreamEnd,
 		})
-	case req.Content != nil:
-		tc := true // default: model responds after this content
-		if req.TurnComplete != nil {
-			tc = *req.TurnComplete
-		}
-		return c.session.SendClientContent(genai.LiveClientContentInput{
-			Turns:        []*genai.Content{req.Content},
-			TurnComplete: &tc,
-		})
+	case len(req.Contents) > 0, req.Content != nil:
+		return c.session.SendClientContent(clientContentInput(req))
 	default:
 		return fmt.Errorf("empty LiveRequest: at least one field must be set")
+	}
+}
+
+// clientContentInput translates a content-bearing LiveRequest into the SDK's
+// client-content payload. Contents (a batched turn slice, e.g. history
+// replay) takes precedence over the single-turn Content. A nil TurnComplete
+// defaults to true — the model responds after this content.
+func clientContentInput(req *model.LiveRequest) genai.LiveClientContentInput {
+	tc := true
+	if req.TurnComplete != nil {
+		tc = *req.TurnComplete
+	}
+	turns := req.Contents
+	if len(turns) == 0 {
+		turns = []*genai.Content{req.Content}
+	}
+	return genai.LiveClientContentInput{
+		Turns:        turns,
+		TurnComplete: &tc,
 	}
 }
 

--- a/model/gemini/gemini_live_test.go
+++ b/model/gemini/gemini_live_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gemini
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/model"
+)
+
+func TestClientContentInput(t *testing.T) {
+	userTurn := genai.NewContentFromText("hello", genai.RoleUser)
+	modelTurn := genai.NewContentFromText("hi there", genai.RoleModel)
+	falseVal := false
+	trueVal := true
+
+	tests := []struct {
+		name         string
+		req          *model.LiveRequest
+		wantTurns    []*genai.Content
+		wantComplete bool
+	}{
+		{
+			name:         "single content defaults to turn complete",
+			req:          &model.LiveRequest{Content: userTurn},
+			wantTurns:    []*genai.Content{userTurn},
+			wantComplete: true,
+		},
+		{
+			name:         "single content explicit false",
+			req:          &model.LiveRequest{Content: userTurn, TurnComplete: &falseVal},
+			wantTurns:    []*genai.Content{userTurn},
+			wantComplete: false,
+		},
+		{
+			name: "batched contents preserve order and explicit false",
+			req: &model.LiveRequest{
+				Contents:     []*genai.Content{userTurn, modelTurn},
+				TurnComplete: &falseVal,
+			},
+			wantTurns:    []*genai.Content{userTurn, modelTurn},
+			wantComplete: false,
+		},
+		{
+			name: "batched contents explicit true",
+			req: &model.LiveRequest{
+				Contents:     []*genai.Content{userTurn, modelTurn, userTurn},
+				TurnComplete: &trueVal,
+			},
+			wantTurns:    []*genai.Content{userTurn, modelTurn, userTurn},
+			wantComplete: true,
+		},
+		{
+			name: "contents wins over content when both set",
+			req: &model.LiveRequest{
+				Content:      modelTurn,
+				Contents:     []*genai.Content{userTurn},
+				TurnComplete: &falseVal,
+			},
+			wantTurns:    []*genai.Content{userTurn},
+			wantComplete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clientContentInput(tt.req)
+			if len(got.Turns) != len(tt.wantTurns) {
+				t.Fatalf("Turns len = %d, want %d", len(got.Turns), len(tt.wantTurns))
+			}
+			for i := range got.Turns {
+				if got.Turns[i] != tt.wantTurns[i] {
+					t.Errorf("Turns[%d] = %p, want %p", i, got.Turns[i], tt.wantTurns[i])
+				}
+			}
+			if got.TurnComplete == nil {
+				t.Fatal("TurnComplete is nil, want explicit value")
+			}
+			if *got.TurnComplete != tt.wantComplete {
+				t.Errorf("TurnComplete = %v, want %v", *got.TurnComplete, tt.wantComplete)
+			}
+		})
+	}
+}

--- a/model/llm.go
+++ b/model/llm.go
@@ -99,15 +99,22 @@ type LiveCapableLLM interface {
 }
 
 // LiveRequest discriminates between message types sent to a live connection.
-// Exactly one field should be set per request.
+// Exactly one payload field (Content, Contents, RealtimeInput, ToolResponse,
+// Close) should be set per request.
 type LiveRequest struct {
-	Content       *genai.Content
+	Content *genai.Content
+	// Contents carries a batch of turns delivered in a single client-content
+	// message — used to replay conversation history on fresh connects.
+	// Mutually exclusive with Content; if both are set, Contents wins.
+	// Unrelated to LLMRequest.Contents, which is the unary-request history.
+	Contents      []*genai.Content
 	RealtimeInput *genai.LiveRealtimeInput
 	ToolResponse  []*genai.FunctionResponse
 	Close         bool
-	// TurnComplete controls whether the model should respond after this content.
-	// nil defaults to true (backwards compatible). Set to false when sending
-	// history turns that the model should absorb without responding.
+	// TurnComplete controls whether the model should respond after this
+	// content. nil defaults to true (backwards compatible). History replay
+	// sets it explicitly: true only when the last replayed turn is an
+	// unanswered user turn, so a model-final history is absorbed silently.
 	TurnComplete *bool
 
 	// EnqueuedAt is stamped when the request enters the LiveRequestQueue.

--- a/runner/runner_live_test.go
+++ b/runner/runner_live_test.go
@@ -16,9 +16,11 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"io"
 	"iter"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -664,10 +666,64 @@ func TestScenario4_ReceiveError(t *testing.T) {
 // Scenario 5: Connection error mid-stream (send side)
 // ---------------------------------------------------------------------------
 
-func TestScenario5_SendError(t *testing.T) {
+// containsErr reports whether any collected error matches target via
+// errors.Is. Send failures can be accompanied by an EOF from the receiver
+// unwinding after the connection closes, so assertions must check
+// containment rather than the exact or final error.
+func containsErr(errs []error, target error) bool {
+	for _, err := range errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScenario5_SendError_HistoryFails(t *testing.T) {
 	conn := newMockLiveConnection()
 	conn.recvCh = make(chan *model.LLMResponse, 10) // blocks until close
-	conn.sendErrAt = 2
+	// The batched history replay is deterministically send #0: it happens
+	// in runSession before the sender/receiver loops start.
+	conn.sendErrAt = 0
+	conn.sendErr = io.ErrClosedPipe
+
+	priorEvents := []*session.Event{
+		{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hello", "user")}, Author: "user"},
+		{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hi", "model")}, Author: "test_agent"},
+	}
+
+	r, _, _ := setupRunnerWithEvents(t, conn, nil, nil, priorEvents)
+
+	queue := agent.NewLiveRequestQueue(100)
+	queue.Close() // failure happens during history handoff, before the loops
+
+	_, errs := collectEvents(t, r, queue)
+
+	found := false
+	for _, err := range errs {
+		if errors.Is(err, io.ErrClosedPipe) && strings.Contains(err.Error(), "history handoff failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'history handoff failed' error wrapping %v, got %v", io.ErrClosedPipe, errs)
+	}
+
+	// Failed sends are not logged by the mock; nothing succeeded.
+	if sendLog := conn.SendLog(); len(sendLog) != 0 {
+		t.Errorf("expected 0 successful sends, got %d", len(sendLog))
+	}
+
+	if !conn.WasClosed() {
+		t.Error("expected connection to be closed")
+	}
+}
+
+func TestScenario5_SendError_QueueSendFails(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 10) // blocks until close
+	// Send #0 is the batched history replay; #1 is the queued message.
+	conn.sendErrAt = 1
 	conn.sendErr = io.ErrClosedPipe
 
 	priorEvents := []*session.Event{
@@ -688,13 +744,16 @@ func TestScenario5_SendError(t *testing.T) {
 
 	_, errs := collectEvents(t, r, queue)
 
-	if len(errs) == 0 {
-		t.Fatal("expected send error")
+	if !containsErr(errs, io.ErrClosedPipe) {
+		t.Fatalf("expected a send error matching %v, got %v", io.ErrClosedPipe, errs)
 	}
 
 	sendLog := conn.SendLog()
-	if len(sendLog) != 2 {
-		t.Errorf("expected 2 successful sends (history), got %d", len(sendLog))
+	if len(sendLog) != 1 {
+		t.Fatalf("expected 1 successful send (batched history), got %d", len(sendLog))
+	}
+	if len(sendLog[0].Contents) != 2 {
+		t.Errorf("history batch size = %d, want 2", len(sendLog[0].Contents))
 	}
 
 	if !conn.WasClosed() {
@@ -735,23 +794,78 @@ func TestScenario6_HistoryHandoff(t *testing.T) {
 	collectEvents(t, r, queue)
 
 	sendLog := conn.SendLog()
-	if len(sendLog) < 5 {
-		t.Fatalf("expected at least 5 sends (4 history + 1 queue), got %d", len(sendLog))
+	if len(sendLog) != 2 {
+		t.Fatalf("expected 2 sends (1 batched history + 1 queue message), got %d", len(sendLog))
 	}
 
-	// First 4 should be history
-	for i := range 4 {
-		if sendLog[i].Content == nil {
-			t.Errorf("send[%d] should have Content (history)", i)
+	// Send #0 is the whole history as one batch, in order.
+	hist := sendLog[0]
+	if len(hist.Contents) != 4 {
+		t.Fatalf("history batch size = %d, want 4", len(hist.Contents))
+	}
+	wantTexts := []string{"Hello", "Hi there", "What's the weather?", "Let me check"}
+	for i, want := range wantTexts {
+		if got := hist.Contents[i].Parts[0].Text; got != want {
+			t.Errorf("history[%d] = %q, want %q", i, got, want)
 		}
 	}
-
-	// 5th should be the queue message
-	if sendLog[4].Content == nil {
-		t.Error("send[4] should have Content (queue message)")
+	// The fixture ends on a model turn — the exact #48 bug: the replay must
+	// NOT invite a response.
+	if hist.TurnComplete == nil || *hist.TurnComplete {
+		t.Error("model-final history replay must carry TurnComplete=false")
 	}
-	if sendLog[4].Content.Parts[0].Text != "new question" {
-		t.Errorf("expected 'new question', got %q", sendLog[4].Content.Parts[0].Text)
+
+	// Send #1 is the queue message.
+	if sendLog[1].Content == nil {
+		t.Fatal("send[1] should have Content (queue message)")
+	}
+	if sendLog[1].Content.Parts[0].Text != "new question" {
+		t.Errorf("expected 'new question', got %q", sendLog[1].Content.Parts[0].Text)
+	}
+}
+
+// TestScenario6_HistoryHandoff_UserFinal is the counterpart fixture: history
+// ending on an unanswered user turn must invite exactly one response.
+func TestScenario6_HistoryHandoff_UserFinal(t *testing.T) {
+	conn := newMockLiveConnection()
+	conn.recvCh = make(chan *model.LLMResponse, 10)
+
+	priorEvents := []*session.Event{
+		{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hello", "user")}, Author: "user"},
+		{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Hi there", "model")}, Author: "test_agent"},
+		{LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What's the weather?", "user")}, Author: "user"},
+	}
+
+	r, _, _ := setupRunnerWithEvents(t, conn, nil, nil, priorEvents)
+
+	queue := agent.NewLiveRequestQueue(100)
+
+	go func() {
+		// Wait for the history send, then let the model "answer" and close.
+		time.Sleep(100 * time.Millisecond)
+		conn.recvCh <- turnCompleteResponse()
+		time.Sleep(50 * time.Millisecond)
+		queue.Close()
+	}()
+
+	collectEvents(t, r, queue)
+
+	sendLog := conn.SendLog()
+	if len(sendLog) != 1 {
+		t.Fatalf("expected 1 send (batched history), got %d", len(sendLog))
+	}
+	hist := sendLog[0]
+	if len(hist.Contents) != 3 {
+		t.Fatalf("history batch size = %d, want 3", len(hist.Contents))
+	}
+	wantTexts := []string{"Hello", "Hi there", "What's the weather?"}
+	for i, want := range wantTexts {
+		if got := hist.Contents[i].Parts[0].Text; got != want {
+			t.Errorf("history[%d] = %q, want %q", i, got, want)
+		}
+	}
+	if hist.TurnComplete == nil || !*hist.TurnComplete {
+		t.Error("user-final history replay must carry TurnComplete=true")
 	}
 }
 
@@ -2947,11 +3061,15 @@ func TestScenario17_NonResumableClearsHandle(t *testing.T) {
 		AppName: "test", UserID: "user1", SessionID: "sess1",
 	})
 
-	// Append a prior event so the resume-vs-fresh history assertions below
+	// Append prior events so the resume-vs-fresh history assertions below
 	// are meaningful — without prior turns, sendHistory has nothing to
-	// send regardless of handle state.
-	if err := svc.Service.AppendEvent(context.Background(), createResp.Session, priorUserEvent("hello")); err != nil {
-		t.Fatal(err)
+	// send regardless of handle state. The history deliberately ends on a
+	// model turn: the mid-session reconnect after a non-resumable clear
+	// (conn3) replays it and must NOT invite a response (#48).
+	for _, ev := range []*session.Event{priorUserEvent("hello"), priorModelEvent("hi there")} {
+		if err := svc.Service.AppendEvent(context.Background(), createResp.Session, ev); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	r, _ := New(Config{
@@ -3029,6 +3147,33 @@ func TestScenario17_NonResumableClearsHandle(t *testing.T) {
 	if !hasContentSend(conn3.SendLog()) {
 		t.Error(`conn3 (fresh after non-resumable clear, handle="") should have history replay`)
 	}
+
+	// Both fresh connects must replay the model-final history as a single
+	// ordered batch that does not invite a response — the reconnect path
+	// (conn3) hits the same #48 bug as the initial connect.
+	for _, fresh := range []struct {
+		name string
+		conn *mockLiveConnection
+	}{{"conn1", conn1}, {"conn3", conn3}} {
+		batch := findHistoryBatch(fresh.conn.SendLog())
+		if batch == nil {
+			t.Errorf("%s: no batched history replay found", fresh.name)
+			continue
+		}
+		if len(batch.Contents) != 2 {
+			t.Errorf("%s: history batch size = %d, want 2", fresh.name, len(batch.Contents))
+			continue
+		}
+		if got := batch.Contents[0].Parts[0].Text; got != "hello" {
+			t.Errorf("%s: history[0] = %q, want %q", fresh.name, got, "hello")
+		}
+		if got := batch.Contents[1].Parts[0].Text; got != "hi there" {
+			t.Errorf("%s: history[1] = %q, want %q", fresh.name, got, "hi there")
+		}
+		if batch.TurnComplete == nil || *batch.TurnComplete {
+			t.Errorf("%s: model-final replay must carry TurnComplete=false", fresh.name)
+		}
+	}
 }
 
 // waitForCond polls cond until it returns true or the deadline expires.
@@ -3056,15 +3201,36 @@ func priorUserEvent(text string) *session.Event {
 	return ev
 }
 
-// hasContentSend reports whether log contains a LiveRequest carrying a
-// non-nil Content payload — i.e., a history-replay turn.
+// priorModelEvent builds a session.Event with model-role text content, so a
+// replayed history can end on a model turn (the #48 fixture).
+func priorModelEvent(text string) *session.Event {
+	ev := session.NewEvent("prior")
+	ev.Author = "test_agent"
+	ev.LLMResponse.Content = genai.NewContentFromText(text, "model")
+	return ev
+}
+
+// hasContentSend reports whether log contains a LiveRequest carrying
+// conversation content — a batched history replay (Contents) or a
+// single-turn message (Content).
 func hasContentSend(log []*model.LiveRequest) bool {
 	for _, req := range log {
-		if req.Content != nil {
+		if req.Content != nil || len(req.Contents) > 0 {
 			return true
 		}
 	}
 	return false
+}
+
+// findHistoryBatch returns the first LiveRequest in log carrying a batched
+// history replay, or nil if none was sent.
+func findHistoryBatch(log []*model.LiveRequest) *model.LiveRequest {
+	for _, req := range log {
+		if len(req.Contents) > 0 {
+			return req
+		}
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #48

**Problem:**

On every fresh Live connect, `sendHistory` replayed the stored thread per-turn and left the last turn's `TurnComplete=nil`, which the gemini wire layer defaults to `true` — per the Live API spec, an instruction to *start generating now*. A persisted voice thread almost always ends on a **model** turn, so the model was handed its own last reply plus an invitation to respond, and spoke unprompted right after `session_ready` (downstream: hulilabs/huli#3113). The same bug fired on mid-session reconnects after a non-resumable handle clear.

**Solution:**

Match both reference implementations (upstream adk-go `SendHistory`, adk-python `send_history`):

- History goes out as **one batched client-content message** — new `LiveRequest.Contents` union member, translated by a new pure `clientContentInput` helper in `gemini_live.go`.
- **`TurnComplete = last(filtered).Role == "user"`**: a model-final history is absorbed silently; a user-final history (unanswered question / pending tool response) still gets exactly one response.
- Audio parts (inline **and** file data, `audio/*` mime) are filtered out copy-on-write before the role check; turns left empty are dropped. The filter never writes through shared pointers — session events alias persisted history (shallow-copy `AppendEvent`), pinned by a dedicated immutability test.
- The `handle == ""` gate, `trackedSend` timing stats, and the `"history handoff failed"` error wrap are unchanged — *when* history is sent didn't change, only *how*.

Intended behavior deltas: an all-audio history now sends zero frames (previously N audio turns + a response invitation), and zero-part turns are dropped (previously sent).

`sendHistory` moved to `internal/llminternal/liveflow/history.go` (function-level move, matches the package's file layout).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New `liveflow/history_test.go` (10 cases: model-final / user-final / tool-response-final semantics, inline+file audio stripping, TurnComplete computed on the filtered list, empty/all-audio → no send, nil-content/nil-part safety, immutability of persisted history, send-error propagation) and new `gemini/gemini_live_test.go` (wire translation: order, defaults, precedence). Runner scenarios updated: Scenario 5 split into history-failure (`sendErrAt=0`, asserts the `history handoff failed` wrap) and queue-failure (`sendErrAt=1`, EOF-tolerant containment) variants; Scenario 6 asserts the exact batch shape for model-final plus a new user-final variant; Scenario 17 now replays a model-final history across the non-resumable reconnect and asserts the batch shape on both fresh connections.

```
go build ./... && go vet ./...        # clean
go test ./...                         # all pass except pre-existing TestDebugTelemetryGetSpansBySessionID
                                      # (server/adkrest/internal/services) which fails identically on clean main
                                      # in this local env (go1.26.0) and is unrelated; CI on main is green
go test -race -count=2 ./internal/llminternal/liveflow/ ./model/gemini/ ./runner/   # all pass
```

**Manual End-to-End (E2E) Tests:**

Downstream live QA runs at the version-bump step per the release checklist in #48: thread ending on a model turn → open voice → protocol monitor shows zero unprompted model turns after connect; thread ending on a user turn → exactly one response; regression pass on normal turns, tool calls, barge-in.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. *(deferred to the downstream QA step in the #48 release checklist — needs the huli voice stack)*
- [x] Any dependent changes have been merged and published in downstream modules. *(none — downstream bump happens after the `-live` tag)*

### Additional context

Review process: plan and implementation each passed three independent model-diverse reviews (Fable / Opus / Sonnet lenses with cross-model adversarial verification of findings) plus a final ChatGPT Codex gate (verdict: GO, no remaining defects). Aligned with adk-python per CONTRIBUTING's alignment requirement — same `turn_complete` semantics and audio filtering as `gemini_llm_connection.py::send_history`, including the filtered-list evaluation (`test_send_history_turn_complete_determined_by_filtered_content` parity). Out of scope per #48: gemini-3.x gate / `history_config.initial_history_in_client_content` (not exposed by go-genai through v1.62.0) and switching the history source to preprocessed contents (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dk1hQdP2c8s6nenws42CD