### PR TITLE
fix(llminternal): keep latest function response as the final content when rearranging history

### DIFF
--- a/internal/llminternal/contents_processor.go
+++ b/internal/llminternal/contents_processor.go
@@ -326,6 +326,11 @@ SearchLoop: // A label to allow breaking out of the nested loop
 // responses may not have originally been consecutive. It preserves all
 // non-tool-call events (like user messages) in their original order.
 //
+// The call/response pair answered by the final event in the history is
+// emitted last: the latest function response is the newest information in
+// the session, and models act on the final contents, so it must not be
+// re-attached mid-history behind older (now stale) exchanges.
+//
 // It returns a new, correctly ordered slice of events or an error if the
 // history is malformed (e.g., a response is found without a corresponding call).
 func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*session.Event, error) {
@@ -345,8 +350,16 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 		}
 	}
 
+	// The last event is the model's freshest information. When it is a
+	// function response (e.g. a long running tool completed after later,
+	// unrelated exchanges), its call/response pair must remain the last
+	// exchange in the rebuilt history.
+	lastEventIndex := len(events) - 1
+
 	// Rebuild the event list
 	var resultEvents []*session.Event
+	// Call/response pair answered by the final event; appended last.
+	var tailPair []*session.Event
 
 	for _, event := range events {
 		// If the event contains responses, skip it. It will be handled
@@ -360,9 +373,6 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 			// This is a regular event (e.g., user message). Just append it.
 			resultEvents = append(resultEvents, event)
 		} else {
-			// This is a function call event, append it and search for responses
-			resultEvents = append(resultEvents, event)
-
 			// Find the unique indices of all corresponding response events.
 			// Using a map[int]struct{} as a set.
 			responseEventIndicesSet := make(map[int]struct{})
@@ -372,6 +382,15 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 				}
 			}
 
+			// This is a function call event: append it, then its responses.
+			// If the pair is answered by the final event, route the whole
+			// pair (call + consolidated response) to the tail instead.
+			dst := &resultEvents
+			if _, found := responseEventIndicesSet[lastEventIndex]; found {
+				dst = &tailPair
+			}
+			*dst = append(*dst, event)
+
 			// If no responses were found for any calls in this event, continue.
 			if len(responseEventIndicesSet) == 0 {
 				continue
@@ -380,7 +399,7 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 			// If there's only one unique response event, append it directly.
 			if len(responseEventIndicesSet) == 1 {
 				for index := range responseEventIndicesSet { // A trick to get the single key
-					resultEvents = append(resultEvents, events[index])
+					*dst = append(*dst, events[index])
 				}
 			} else {
 				// Multiple response events exist for that function call so we merge them.
@@ -402,12 +421,12 @@ func rearrangeEventsForFunctionResponsesInHistory(events []*session.Event) ([]*s
 				if err != nil {
 					return nil, fmt.Errorf("failed to merge response events: %w", err)
 				}
-				resultEvents = append(resultEvents, mergedEvent)
+				*dst = append(*dst, mergedEvent)
 			}
 		}
 	}
 
-	return resultEvents, nil
+	return append(resultEvents, tailPair...), nil
 }
 
 // mergeFunctionResponseEvents merges a list of function response events into one.

--- a/internal/llminternal/contents_processor_test.go
+++ b/internal/llminternal/contents_processor_test.go
@@ -810,6 +810,44 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 		Response: map[string]any{"confirmed": false},
 	}
 
+	// Async Call/Responses: a long-running call whose final response arrives
+	// after later, unrelated exchanges (the async / late-completion flow).
+	fcAsyncPlan := &genai.FunctionCall{
+		ID:   "async_plan_call",
+		Name: "plan_tool",
+		Args: map[string]any{"task": "feature"},
+	}
+	frAsyncPlanAck := &genai.FunctionResponse{
+		ID:       "async_plan_call",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "dispatched"},
+	}
+	frAsyncPlanFinal := &genai.FunctionResponse{
+		ID:       "async_plan_call",
+		Name:     "plan_tool",
+		Response: map[string]any{"status": "completed", "result": "plan ready"},
+	}
+	fcAsyncStatus := &genai.FunctionCall{
+		ID:   "async_status_call",
+		Name: "status_tool",
+		Args: map[string]any{"target": "plan"},
+	}
+	frAsyncStatus := &genai.FunctionResponse{
+		ID:       "async_status_call",
+		Name:     "status_tool",
+		Response: map[string]any{"status": "running", "elapsed": "21s"},
+	}
+	fcAsyncWait := &genai.FunctionCall{
+		ID:   "async_wait_call",
+		Name: "wait_for",
+		Args: map[string]any{"target": "plan"},
+	}
+	frAsyncWait := &genai.FunctionResponse{
+		ID:       "async_wait_call",
+		Name:     "wait_for",
+		Response: map[string]any{"status": "timeout"},
+	}
+
 	// Error Call/Response
 	frOrphaned := &genai.FunctionResponse{
 		ID:       "no_matching_call",
@@ -879,12 +917,138 @@ func TestContentsRequestProcessor_Rearrange(t *testing.T) {
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
 				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinal, "user")}},
 			},
+			// The completed long-running pair stays LAST: frLROFinal is the
+			// newest information in the session, and models act on the final
+			// contents. The unrelated fcBasic exchange is still preserved (the
+			// property this case exists to verify) — before the completion, no
+			// longer after it, so the freshest response is never buried behind
+			// a stale exchange.
 			want: []*genai.Content{
 				genai.NewContentFromText("Run long process and search", "user"),
-				NewContentFromFunctionCall(fcLRO, "model"),
-				NewContentFromFunctionResponse(frLROFinal, "user"),
 				NewContentFromFunctionCall(fcBasic, "model"),
 				NewContentFromFunctionResponse(frBasic, "user"),
+				NewContentFromFunctionCall(fcLRO, "model"),
+				NewContentFromFunctionResponse(frLROFinal, "user"),
+			},
+		},
+		{
+			// A long-running tool's completion arrives as the last event, after
+			// an unrelated status exchange. The completion is the newest
+			// information: its call/response pair must remain the LAST contents.
+			// Intervening plain-text events are dropped by
+			// rearrangeEventsForLatestFunctionResponse (pre-existing behavior,
+			// matches adk-python).
+			name: "Late async completion stays the final content",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan how to add feature Q", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncPlan, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("I dispatched the planning task.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What is the status?", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncStatus, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan how to add feature Q", "user"),
+				NewContentFromFunctionCall(fcAsyncStatus, "model"),
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+				NewContentFromFunctionCall(fcAsyncPlan, "model"),
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
+			},
+		},
+		{
+			// Production shape (Gemini): model turns carry text alongside the
+			// FunctionCall part, and tool acks are authored by the agent. The
+			// tail pair moves as a unit, carrying its text part with it.
+			name: "Late async completion stays final with mixed text and call parts",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Plan the new subcommand", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Planning..."}, {FunctionCall: fcAsyncPlan}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanAck, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("The planning agent is running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("What's the status?", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Checking..."}, {FunctionCall: fcAsyncStatus}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: &genai.Content{Role: "model", Parts: []*genai.Part{{Text: "Waiting..."}, {FunctionCall: fcAsyncWait}}}}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncWait, "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Still running.", "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncPlanFinal, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Plan the new subcommand", "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Checking..."}, {FunctionCall: fcAsyncStatus}}},
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Waiting..."}, {FunctionCall: fcAsyncWait}}},
+				NewContentFromFunctionResponse(frAsyncWait, "user"),
+				{Role: "model", Parts: []*genai.Part{{Text: "Planning..."}, {FunctionCall: fcAsyncPlan}}},
+				NewContentFromFunctionResponse(frAsyncPlanFinal, "user"),
+			},
+		},
+		{
+			// Naturally ordered history: the final response is already adjacent
+			// to its call. The tail-pair relocation must be an identity
+			// operation.
+			name: "Adjacent final response after earlier exchange keeps order",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Search then check status", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Now the status", "user")}},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcAsyncStatus, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frAsyncStatus, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Search then check status", "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				genai.NewContentFromText("Now the status", "user"),
+				NewContentFromFunctionCall(fcAsyncStatus, "model"),
+				NewContentFromFunctionResponse(frAsyncStatus, "user"),
+			},
+		},
+		{
+			// Parallel calls whose late merged completion arrives last, with an
+			// unrelated exchange in between: the parallel pair moves to the
+			// tail as one unit (both calls, both responses).
+			name: "Late parallel completion stays final past unrelated exchange",
+			events: []*session.Event{
+				{Author: "user", LLMResponse: model.LLMResponse{Content: genai.NewContentFromText("Analyze and search, then look up basics", "user")}},
+				{
+					Author: agentName,
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{{FunctionCall: fcLROMixed}, {FunctionCall: fcNormalMixed}},
+						},
+					},
+				},
+				{
+					Author: "user",
+					LLMResponse: model.LLMResponse{
+						Content: &genai.Content{
+							Role:  "user",
+							Parts: []*genai.Part{{FunctionResponse: frLROInterMixed}, {FunctionResponse: frNormalMixed}},
+						},
+					},
+				},
+				{Author: agentName, LLMResponse: model.LLMResponse{Content: NewContentFromFunctionCall(fcBasic, "model")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frBasic, "user")}},
+				{Author: "user", LLMResponse: model.LLMResponse{Content: NewContentFromFunctionResponse(frLROFinalMixed, "user")}},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromText("Analyze and search, then look up basics", "user"),
+				NewContentFromFunctionCall(fcBasic, "model"),
+				NewContentFromFunctionResponse(frBasic, "user"),
+				{
+					Role:  "model",
+					Parts: []*genai.Part{{FunctionCall: fcLROMixed}, {FunctionCall: fcNormalMixed}},
+				},
+				{
+					Role:  "user",
+					Parts: []*genai.Part{{FunctionResponse: frLROFinalMixed}, {FunctionResponse: frNormalMixed}},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Ports upstream google/adk-go#1182 (fix for google/adk-go#1181). Closes #52.

## Problem

In `ContentsRequestProcessor`, pass 1 (`rearrangeEventsForLatestFunctionResponse`) correctly places a long-running tool's late final FunctionResponse last when it arrives as the latest session event — but pass 2 (`rearrangeEventsForFunctionResponsesInHistory`) re-attached every response immediately after its call, including the merged late response pass 1 had just deliberately placed last. The completion got buried mid-history and a stale tool exchange remained the final content models act on, so they answered the stale exchange and never saw the completion.

## Fix

Pass 2 keeps its call/response adjacency invariant and adds one rule: the call/response pair answered by the **final** event is routed to a `tailPair` slice emitted last. Pure no-op when the last event is not a function response. Preserves upstream #767's no-drop property (#761); disjoint from the #760 orphan path.

## Why a direct port

Upstream now lives on the `google.golang.org/adk/v2` module path; this fork keeps v1, so the fix cannot arrive via a normal upstream sync. Carried as `git cherry-pick -x` of upstream commit `5bb4691238e631d5bc4445a058bad9226e10b227` (PR google/adk-go#1182, open/CI-green at time of port; same author). Precedent: #46 (port of upstream google/adk-go#673).

- No API, dependency, or go.mod changes; no import-line changes — the fork's v1 imports are untouched.
- Verified equivalence: `gh pr diff 1182 --repo google/adk-go | git apply --check -R` is clean against this branch (the tree contains exactly the upstream PR's changes), and `git diff main | grep '/v2/'` is empty.
- Only consumer is the request pipeline (`internal/llminternal/base_flow.go`); liveflow does not use this processor.

## Testing Plan

- [x] `go test -race -mod=readonly -count=1 ./internal/llminternal/...`
- [x] `go build -mod=readonly ./...`
- [x] `go test -race -mod=readonly -count=1 -shuffle=on ./...` (full suite, exit 0)
- [x] `golangci-lint run` (0 issues)
- [x] `go mod tidy -diff` (clean)
- [x] Reverse-apply equivalence vs upstream PR #1182 (clean)

The ported tests exercise the regression directly (7 new fixtures, 4 new table rows, 1 updated expectation):

```
=== RUN   TestContentsRequestProcessor_Rearrange/Late_async_completion_stays_the_final_content
=== RUN   TestContentsRequestProcessor_Rearrange/Late_async_completion_stays_final_with_mixed_text_and_call_parts
=== RUN   TestContentsRequestProcessor_Rearrange/Adjacent_final_response_after_earlier_exchange_keeps_order
=== RUN   TestContentsRequestProcessor_Rearrange/Late_parallel_completion_stays_final_past_unrelated_exchange
--- PASS: TestContentsRequestProcessor_Rearrange (0.01s)
PASS
ok  	google.golang.org/adk/internal/llminternal	1.356s
```

If upstream amends #1182 before merging it, we true-up in a follow-up; the `(cherry picked from commit 5bb4691…)` trailer keeps the ported baseline auditable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiTBwFdpNS7xCGUXgZgJkg
